### PR TITLE
Kubernetes deployment descriptor & instructions

### DIFF
--- a/kubernetes/config.yml
+++ b/kubernetes/config.yml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+metadata:
+  labels:
+    app: vmware-exporter
+  name: vmware-exporter-config
+apiVersion: v1
+data:
+  VSPHERE_USER: "<USER>"
+  VSPHERE_HOST: "<HOST>"
+  VSPHERE_IGNORE_SSL: "True"
+  VSPHERE_COLLECT_HOSTS: "True"
+  VSPHERE_COLLECT_DATASTORES: "True"
+  VSPHERE_COLLECT_VMS: "True"

--- a/kubernetes/readme.md
+++ b/kubernetes/readme.md
@@ -1,0 +1,15 @@
+
+# Vmware node exporter on kubernetes
+
+First edit the config.yml file to match your setup.
+Afterwards, using the read command interactively type in your password, 
+then run the command to create your secret on the cluster.
+And finally deploy the exporter container.
+
+The pod has prometheus annotations so when there's a prometheus on the cluster it will auto scrape the pod.
+
+```
+read -s VSPHERE_PASSWORD
+kubectl create secret generic vmware-exporter-password --from-literal=VSPHERE_PASSWORD=$VSPHERE_PASSWORD
+kubectl apply -f . 
+```

--- a/kubernetes/vmware-exporter.yml
+++ b/kubernetes/vmware-exporter.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmware-exporter
+spec:
+  selector:
+    matchLabels:
+      app: vmware-exporter
+  template:
+    metadata:
+      labels:
+        app: vmware-exporter
+        release: vmware-exporter
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9272"
+        prometheus.io/scrape: "true"
+    spec:
+      containers:
+      - name: vmware-exporter
+        image: "pryorda/vmware_exporter:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9272
+          name: http
+        envFrom:
+        - configMapRef:
+            name: vmware-exporter-config
+        - secretRef:
+            name: vmware-exporter-password


### PR DESCRIPTION
Hi,

I thought I would share these kubernetes descriptors if people would like to run your docker container on a kubernetes cluster.

It has the prometheus.io annotations so in case your cluster already has a prometheus server it should pick up this endpoint automatically. 

I've tested this on a rancher installed kubernetes 1.10 cluster.
![image](https://user-images.githubusercontent.com/999774/43893160-4a500f7a-9bce-11e8-8311-2470b10c3d3c.png)

Kind regards,
Kris