### PR TITLE
Adding datacenter, cluster/ds_cluster labels + some new metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN set -x; buildDeps="gcc python-dev musl-dev libffi-dev openssl openssl-dev" \
 
 EXPOSE 9272
 
-CMD ["/opt/vmware_exporter/vmware_exporter/vmware_exporter.py"]
+ENTRYPOINT ["python", "-u", "/opt/vmware_exporter/vmware_exporter/vmware_exporter.py"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you want to limit the scope of the metrics gather you can update the subsyste
         vms: False
         datastores: True
         hosts: True
+        snapshots: True
 
 This would only connect datastores and hosts.
 
@@ -44,6 +45,7 @@ default:
         vms: True
         datastores: True
         hosts: True
+        snapshots: True
 
 esx:
     vsphere_host: vc.example2.com
@@ -54,6 +56,7 @@ esx:
         vms: False
         datastores: False
         hosts: True
+        snapshots: True
 
 limited:
     vsphere_host: slowvc.example.com
@@ -64,6 +67,7 @@ limited:
         vms: False
         datastores: True
         hosts: False
+        snapshots: False
         
         
 # Example of Multiple Vcenter usage per #23
@@ -93,9 +97,10 @@ limited:
 | `VSPHERE_USER`               | config, env            | n/a      | User for connecting to vsphere |
 | `VSPHERE_PASSWORD`           | config, env            | n/a      | Password for connecting to vsphere |
 | `VSPHERE_IGNORE_SSL`         | config, env            | False    | Ignore the ssl cert on the connection to vsphere host |
-| `VSPHERE_COLLECT_HOSTS`      | config, env            | True     | Set to false to disable collect of hosts |
-| `VSPHERE_COLLECT_DATASTORES` | config, env            | True     | Set to false to disable collect of datastores |
-| `VSPHERE_COLLECT_VMS`        | config, env            | True     | Set to false to disable collect of virtual machines |
+| `VSPHERE_COLLECT_HOSTS`      | config, env            | True     | Set to false to disable collection of host metrics |
+| `VSPHERE_COLLECT_DATASTORES` | config, env            | True     | Set to false to disable collection of datastore metrics |
+| `VSPHERE_COLLECT_VMS`        | config, env            | True     | Set to false to disable collection of virtual machine metrics |
+| `VSPHERE_COLLECT_SNAPSHOTS`  | config, env            | True     | Set to false to disable collection of snapshot metrics |
 
 ### Prometheus configuration
 


### PR DESCRIPTION
@pryorda, this fixes https://github.com/pryorda/vmware_exporter/issues/4

This PR implements additional metadata metrics that allows to associate Hosts and VMs to Datacenters and Clusters.

New metrics:
```
vmware_dc_info{dc_name} 1
vmware_dc_cluster_info{dc_name,cluster_name} 1
vmware_dc_cluster_host_info{dc_name,cluster_name,host_name} 1
vmware_dc_cluster_host_vm_info{dc_name,cluster_name,host_name,vm_name} 1
```

Few more minor things:
1) Dockerfile modified to use `ENTRYPOINT` instead of `CMD` so it would be easier to specify a custom config file location.
2) Separated snapshot metrics to its own metrics sub-collection, so these can also be controlled via the `collect_only` section.
3) Few minor log adjustments and re-phrasing