### PR TITLE
Bug/29 Fixed bug where replace would fail if the label value was None

### DIFF
--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -125,7 +125,7 @@ class VMWareMetricsResource(Resource):
             output.append('# HELP {0} {1}'.format(
                 metric.name, metric.documentation.replace('\\', r'\\').replace('\n', r'\n')))
             output.append('\n# TYPE {0} {1}\n'.format(metric.name, metric.type))
-            for name, labels, value in metric.samples[:3]:
+            for name, labels, value in metric.samples:
                 if labels:
                     labels = {k: v for k, v in labels.items() if v is not None}
                     labelstr = '{{{0}}}'.format(','.join(

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -125,20 +125,22 @@ class VMWareMetricsResource(Resource):
             output.append('# HELP {0} {1}'.format(
                 metric.name, metric.documentation.replace('\\', r'\\').replace('\n', r'\n')))
             output.append('\n# TYPE {0} {1}\n'.format(metric.name, metric.type))
-            for name, labels, value in metric.samples:
-                if labels:
-                    labelstr = '{{{0}}}'.format(','.join(
-                        ['{0}="{1}"'.format(
-                            k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"').encode('utf-8'))
-                         for k, v in sorted(labels.items())]))
+
+            for s in metric.samples:
+                if s.labels:
+                    labels = {k: v for k, v in s.labels.items() if v is not None}
+                    labelstr = '{{{0}}}'.format(','.join(['{0}="{1}"'.format(k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"').encode('utf-8')) for k, v in sorted(labels.items())]))
                 else:
                     labelstr = ''
+
+                value = s.value
                 if isinstance(value, int):
                     value = float(value)
-                if isinstance(value, long):  # noqa: F821
+                if isinstance(s.value, long):  # noqa: F821
                     value = float(value)
                 if isinstance(value, float):
-                    output.append('{0}{1} {2}\n'.format(name, labelstr, _floatToGoString(value)))
+                    output.append('{0}{1} {2}\n'.format(s.name, labelstr, _floatToGoString(s.value)))
+
         if output != []:
             request.write(''.join(output))
             request.finish()

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -125,22 +125,21 @@ class VMWareMetricsResource(Resource):
             output.append('# HELP {0} {1}'.format(
                 metric.name, metric.documentation.replace('\\', r'\\').replace('\n', r'\n')))
             output.append('\n# TYPE {0} {1}\n'.format(metric.name, metric.type))
-
-            for s in metric.samples:
-                if s.labels:
-                    labels = {k: v for k, v in s.labels.items() if v is not None}
-                    labelstr = '{{{0}}}'.format(','.join(['{0}="{1}"'.format(k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"').encode('utf-8')) for k, v in sorted(labels.items())]))
+            for name, labels, value in metric.samples[:3]:
+                if labels:
+                    labels = {k: v for k, v in labels.items() if v is not None}
+                    labelstr = '{{{0}}}'.format(','.join(
+                        ['{0}="{1}"'.format(
+                            k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"').encode('utf-8'))
+                         for k, v in sorted(labels.items())]))
                 else:
                     labelstr = ''
-
-                value = s.value
                 if isinstance(value, int):
                     value = float(value)
-                if isinstance(s.value, long):  # noqa: F821
+                if isinstance(value, long):  # noqa: F821
                     value = float(value)
                 if isinstance(value, float):
-                    output.append('{0}{1} {2}\n'.format(s.name, labelstr, _floatToGoString(s.value)))
-
+                    output.append('{0}{1} {2}\n'.format(name, labelstr, _floatToGoString(value)))
         if output != []:
             request.write(''.join(output))
             request.finish()


### PR DESCRIPTION
When using with ESXi (and not vSphere), some labels (such as _"cluster_name"_) could be `None`, and an exception is thrown when during a call to the `Str.replace()` method. Removed all `None` values from the labels dictionary to resolve the bug.