### PR TITLE
Speed up build process with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 config.yml
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ LABEL VERSION=0.3.0
 
 WORKDIR /opt/vmware_exporter/
 
-COPY . /opt/vmware_exporter/
+COPY requirements.txt /opt/vmware_exporter/
 
 RUN set -x; buildDeps="gcc python-dev musl-dev libffi-dev openssl openssl-dev" \
  && apk add --no-cache --update $buildDeps \
  && pip install -r requirements.txt \
  && apk del $buildDeps
+
+COPY . /opt/vmware_exporter/
 
 EXPOSE 9272
 


### PR DESCRIPTION
This PR makes usage of the Docker cache and therefore, speeds up the build process when the build is executed multiple times, e.g. for development ;) .
Now it does not always download the build tools, if only a code change has been made.
Also if an virtual environment is used, it will not get copied to docker, this may not effect everybody.