### PR TITLE
WIP - Property collectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ RUN set -x; buildDeps="gcc python-dev musl-dev libffi-dev openssl openssl-dev" \
 
 EXPOSE 9272
 
+ENV PYTHONUNBUFFERED=1
+
 ENTRYPOINT ["/usr/local/bin/vmware_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY . /opt/vmware_exporter/
 
 RUN set -x; buildDeps="gcc python-dev musl-dev libffi-dev openssl openssl-dev" \
  && apk add --no-cache --update $buildDeps \
- && pip install -r requirements.txt \
+ && pip install -r requirements.txt . \
  && apk del $buildDeps
 
 EXPOSE 9272
 
-ENTRYPOINT ["python", "-u", "/opt/vmware_exporter/vmware_exporter/vmware_exporter.py"]
+ENTRYPOINT ["/usr/local/bin/vmware_exporter"]

--- a/vmware_exporter/helpers.py
+++ b/vmware_exporter/helpers.py
@@ -1,0 +1,46 @@
+from pyVmomi import vmodl
+
+
+def batch_fetch_properties(content, obj_type, properties):
+    view_ref = content.viewManager.CreateContainerView(
+        container=content.rootFolder,
+        type=[obj_type],
+        recursive=True
+    )
+
+    PropertyCollector = vmodl.query.PropertyCollector
+
+    # Describe the list of properties we want to fetch for obj_type
+    property_spec = PropertyCollector.PropertySpec()
+    property_spec.type = obj_type
+    property_spec.pathSet = properties
+
+    # Describe where we want to look for obj_type
+    traversal_spec = PropertyCollector.TraversalSpec()
+    traversal_spec.name = 'traverseEntities'
+    traversal_spec.path = 'view'
+    traversal_spec.skip = False
+    traversal_spec.type = view_ref.__class__
+
+    obj_spec = PropertyCollector.ObjectSpec()
+    obj_spec.obj = view_ref
+    obj_spec.skip = True
+    obj_spec.selectSet = [traversal_spec]
+
+    filter_spec = PropertyCollector.FilterSpec()
+    filter_spec.objectSet = [obj_spec]
+    filter_spec.propSet = [property_spec]
+
+    props = content.propertyCollector.RetrieveContents([filter_spec])
+
+    results = {}
+    for obj in props:
+        properties = {}
+        properties['obj'] = obj.obj
+
+        for prop in obj.propSet:
+            properties[prop.name] = prop.val
+
+        results[obj.obj._moId] = properties
+
+    return results

--- a/vmware_exporter/helpers.py
+++ b/vmware_exporter/helpers.py
@@ -37,6 +37,7 @@ def batch_fetch_properties(content, obj_type, properties):
     for obj in props:
         properties = {}
         properties['obj'] = obj.obj
+        properties['id'] = obj.obj._moId
 
         for prop in obj.propSet:
             properties[prop.name] = prop.val

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -13,6 +13,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 import os
 import ssl
+import traceback
 import pytz
 import yaml
 
@@ -52,7 +53,7 @@ class VmwareCollector():
         try:
             future.result()
         except Exception as e:
-            log(str(e))
+            log(traceback.format_exc())
 
     def thread_it(self, method, data):
         future = self.threader.submit(method, *data)
@@ -552,6 +553,8 @@ class VmwareCollector():
                 labels,
                 float(host['summary.hardware.memorySize']) / 1024 / 1024
             )
+
+            raise RuntimeError('Foo')
 
         log("Finished host metrics collection")
 

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -234,21 +234,6 @@ class VmwareCollector():
         """ convert to epoch time """
         return (my_date - datetime(1970, 1, 1, tzinfo=pytz.utc)).total_seconds()
 
-    def _vmware_get_obj(self, content, vimtype, name=None):
-        """
-         Get the vsphere object associated with a given text name
-        """
-        obj = None
-        container = content.viewManager.CreateContainerView(
-            content.rootFolder, vimtype, True)
-        if name:
-            for view in container.view:
-                if view.name == name:
-                    obj = view
-                    return [obj]
-        else:
-            return container.view
-
     def _vmware_connect(self):
         """
         Connect to Vcenter and get connection

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -216,13 +216,13 @@ class VmwareCollector():
             virtual_machines = self._vmware_get_vmguests(content, metrics, host_inventory)
             log("Finished VM Guests metrics collection")
 
-        self.threader.shutdown(wait=True)
-
         if collect_only['vms'] is True:
             counter_info = self._vmware_perf_metrics(content)
             self._vmware_get_vm_perf_manager_metrics(
                 content, counter_info, virtual_machines, metrics, host_inventory
             )
+
+        self.threader.shutdown(wait=True)
 
         self._vmware_disconnect()
         log("Finished collecting metrics from {0}".format(vsphere_host))

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -212,9 +212,9 @@ class VmwareCollector():
 
         # Collect VMs metrics
         if collect_only['vmguests'] is True or collect_only['vms'] is True or collect_only['snapshots'] is True:
-            log("Starting VM Guests metrics collection")
-            virtual_machines = self._vmware_get_vmguests(content, metrics, host_inventory)
-            log("Finished VM Guests metrics collection")
+            log("Starting VM metrics collection")
+            virtual_machines = self._vmware_get_vms(content, metrics, host_inventory)
+            log("Finished VM metrics collection")
 
         if collect_only['vms'] is True:
             counter_info = self._vmware_perf_metrics(content)
@@ -399,9 +399,9 @@ class VmwareCollector():
                 )
         log('FIN: _vmware_get_vm_perf_manager_metrics')
 
-    def _vmware_get_vmguests(self, content, metrics, inventory):
+    def _vmware_get_vms(self, content, metrics, inventory):
         """
-        Get VM Guest information
+        Get VM information
         """
         properties = [
             'name',

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -539,8 +539,6 @@ class VmwareCollector():
                 float(host['summary.hardware.memorySize']) / 1024 / 1024
             )
 
-            raise RuntimeError('Foo')
-
         log("Finished host metrics collection")
 
     def _vmware_get_inventory(self, content):

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -52,7 +52,7 @@ class VmwareCollector():
     def _future_done(self, future):
         try:
             future.result()
-        except Exception as e:
+        except Exception:
             log(traceback.format_exc())
 
     def thread_it(self, method, data):
@@ -313,7 +313,7 @@ class VmwareCollector():
 
             ds_capacity = float(datastore['summary.capacity'])
             ds_freespace = float(datastore['summary.freeSpace'])
-            ds_uncommitted = float(datastore['summary.uncommitted']) if datastore['summary.uncommitted'] else 0
+            ds_uncommitted = float(datastore.get('summary.uncommitted', 0))
             ds_provisioned = ds_capacity - ds_freespace + ds_uncommitted
 
             ds_metrics['vmware_datastore_capacity_size'].add_metric(labels, ds_capacity)
@@ -504,7 +504,6 @@ class VmwareCollector():
                     labels,
                     self._to_epoch(host['runtime.bootTime'])
                 )
-
 
             # Host connection state (connected, disconnected, notResponding)
             host_metrics['vmware_host_connection_state'].add_metric(

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -48,9 +48,15 @@ class VmwareCollector():
         self.ignore_ssl = ignore_ssl
         self.collect_only = collect_only
 
+    def _future_done(self, future):
+        try:
+            future.result()
+        except Exception as e:
+            log(str(e))
+
     def thread_it(self, method, data):
-        # FIXME: Just call submit directly
-        self.threader.submit(method, *data)
+        future = self.threader.submit(method, *data)
+        future.add_done_callback(self._future_done)
 
     def collect(self):
         """ collects metrics """
@@ -191,16 +197,16 @@ class VmwareCollector():
 
         # Collect Datastore metrics
         if collect_only['datastores'] is True:
-            self.threader.submit(
+            self.thread_it(
                 self._vmware_get_datastores,
-                content, metrics, ds_inventory,
+                [content, metrics, ds_inventory],
             )
 
         # Collect Hosts metrics
         if collect_only['hosts'] is True:
-            self.threader.submit(
+            self.thread_it(
                 self._vmware_get_hosts,
-                content, metrics, host_inventory,
+                [content, metrics, host_inventory],
             )
 
         # Collect VMs metrics


### PR DESCRIPTION
So this is a bit rough and ready due to #40.

As you can see from the commit history, I did 7bb7c31 a week ago. I hadn't realised this wasn't part of v0.3.0 so this is a bigger change than anticipated.

The current code does a `_vmware_get_obj` on one thread and then for each result it spawns another thread. Behind the pyvmomi magic, each attribute access on a new ManagedObject triggers an API call. So with 100 vms, thats 101 API calls.

The PropertyCollector API is a lot more sane - you can tell it what kind of object to retrieve, where to retrieve it from and what properties of that object to retrieve. It retrieves it all in one go. This is fast - in my environment its as fast as the current version but doesn't need any child threads and only quries a single API call.

I did this for the `_vmware_get_vm_metrics` code path already, and for #40 i've expanded it for the datastore and host code paths.