### PR TITLE
Embrace more twisted machinery + allow concurrent scrapes

### DIFF
--- a/vmware_exporter/helpers.py
+++ b/vmware_exporter/helpers.py
@@ -8,30 +8,33 @@ def batch_fetch_properties(content, obj_type, properties):
         recursive=True
     )
 
-    PropertyCollector = vmodl.query.PropertyCollector
+    try:
+        PropertyCollector = vmodl.query.PropertyCollector
 
-    # Describe the list of properties we want to fetch for obj_type
-    property_spec = PropertyCollector.PropertySpec()
-    property_spec.type = obj_type
-    property_spec.pathSet = properties
+        # Describe the list of properties we want to fetch for obj_type
+        property_spec = PropertyCollector.PropertySpec()
+        property_spec.type = obj_type
+        property_spec.pathSet = properties
 
-    # Describe where we want to look for obj_type
-    traversal_spec = PropertyCollector.TraversalSpec()
-    traversal_spec.name = 'traverseEntities'
-    traversal_spec.path = 'view'
-    traversal_spec.skip = False
-    traversal_spec.type = view_ref.__class__
+        # Describe where we want to look for obj_type
+        traversal_spec = PropertyCollector.TraversalSpec()
+        traversal_spec.name = 'traverseEntities'
+        traversal_spec.path = 'view'
+        traversal_spec.skip = False
+        traversal_spec.type = view_ref.__class__
 
-    obj_spec = PropertyCollector.ObjectSpec()
-    obj_spec.obj = view_ref
-    obj_spec.skip = True
-    obj_spec.selectSet = [traversal_spec]
+        obj_spec = PropertyCollector.ObjectSpec()
+        obj_spec.obj = view_ref
+        obj_spec.skip = True
+        obj_spec.selectSet = [traversal_spec]
 
-    filter_spec = PropertyCollector.FilterSpec()
-    filter_spec.objectSet = [obj_spec]
-    filter_spec.propSet = [property_spec]
+        filter_spec = PropertyCollector.FilterSpec()
+        filter_spec.objectSet = [obj_spec]
+        filter_spec.propSet = [property_spec]
 
-    props = content.propertyCollector.RetrieveContents([filter_spec])
+        props = content.propertyCollector.RetrieveContents([filter_spec])
+    finally:
+        view_ref.Destroy()
 
     results = {}
     for obj in props:

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -422,7 +422,7 @@ class VmwareCollector():
         )
 
         if self.collect_only['vms'] is True:
-            d = self._vmware_get_vm_perf_manager_metrics(
+            vm_perf_deferred = self._vmware_get_vm_perf_manager_metrics(
                 content, virtual_machines, metrics, inventory
             )
 
@@ -471,7 +471,7 @@ class VmwareCollector():
                         snapshot['timestamp_seconds'],
                     )
 
-        yield d
+        yield vm_perf_deferred
         log("Finished vm metrics collection")
 
     def _vmware_get_hosts(self, content, host_metrics, inventory):

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -403,6 +403,8 @@ class VmwareCollector():
         """
         Get VM information
         """
+        log("Starting vm metrics collection")
+
         properties = [
             'name',
             'runtime.powerState',
@@ -475,6 +477,7 @@ class VmwareCollector():
                     )
 
         yield d
+        log("Finished vm metrics collection")
 
     def _vmware_get_hosts(self, content, host_metrics, inventory):
         """

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -376,9 +376,8 @@ class VmwareCollector():
 
         specs = []
         for vm in virtual_machines.values():
-            # summary = vm.summary
-            # if summary.runtime.powerState != 'poweredOn':
-            #     continue
+            if vm.get('runtime.powerState') != 'poweredOn':
+                continue
             specs.append(vim.PerformanceManager.QuerySpec(
                 maxSample=1,
                 entity=vm['obj'],

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -14,7 +14,6 @@ import os
 import ssl
 import traceback
 import pytz
-import yaml
 
 from yamlconfig import YamlConfig
 
@@ -22,7 +21,6 @@ from yamlconfig import YamlConfig
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from twisted.internet import reactor, endpoints, defer, threads
-from twisted.internet.task import deferLater
 
 # VMWare specific imports
 from pyVmomi import vim, vmodl

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -37,8 +37,6 @@ from .helpers import batch_fetch_properties
 
 class VmwareCollector():
 
-    THREAD_LIMIT = 25
-
     def __init__(self, host, username, password, collect_only, ignore_ssl=False):
         self.host = host
         self.username = username
@@ -729,6 +727,8 @@ def main():
                         default=9272, help="HTTP port to expose metrics")
 
     args = parser.parse_args()
+
+    reactor.suggestThreadPoolSize(25)
 
     # Start up the server to expose the metrics.
     root = Resource()

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -621,32 +621,25 @@ class VMWareMetricsResource(Resource):
                 if 'default' not in self.config.keys():
                     log("Error, you must have a default section in config file (for now)")
                     exit(1)
+                return
             except Exception as exception:
                 raise SystemExit("Error while reading configuration file: {0}".format(exception.message))
-        else:
-            config_data = """
-            default:
-                vsphere_host: "{0}"
-                vsphere_user: "{1}"
-                vsphere_password: "{2}"
-                ignore_ssl: {3}
-                collect_only:
-                    vms: True
-                    vmguests: True
-                    datastores: True
-                    hosts: True
-                    snapshots: True
-            """.format(os.environ.get('VSPHERE_HOST'),
-                       os.environ.get('VSPHERE_USER'),
-                       os.environ.get('VSPHERE_PASSWORD'),
-                       os.environ.get('VSPHERE_IGNORE_SSL', False)
-                       )
-            self.config = yaml.load(config_data)
-            self.config['default']['collect_only']['hosts'] = os.environ.get('VSPHERE_COLLECT_HOSTS', True)
-            self.config['default']['collect_only']['datastores'] = os.environ.get('VSPHERE_COLLECT_DATASTORES', True)
-            self.config['default']['collect_only']['vms'] = os.environ.get('VSPHERE_COLLECT_VMS', True)
-            self.config['default']['collect_only']['vmguests'] = os.environ.get('VSPHERE_COLLECT_VMGUESTS', True)
-            self.config['default']['collect_only']['snapshots'] = os.environ.get('VSPHERE_COLLECT_SNAPSHOTS', True)
+
+        self.config = {
+            'default': {
+                'vsphere_host': os.environ.get('VSPHERE_HOST'),
+                'vsphere_user': os.environ.get('VSPHERE_USER'),
+                'vsphere_password': os.environ.get('VSPHERE_PASSWORD'),
+                'ignore_ssl': os.environ.get('VSPHERE_IGNORE_SSL', False),
+                'collect_only': {
+                    'vms': os.environ.get('VSPHERE_COLLECT_VMS', True),
+                    'vmguests': os.environ.get('VSPHERE_COLLECT_VMGUESTS', True),
+                    'datastores': os.environ.get('VSPHERE_COLLECT_DATASTORES', True),
+                    'hosts': os.environ.get('VSPHERE_COLLECT_HOSTS', True),
+                    'snapshots': os.environ.get('VSPHERE_COLLECT_SNAPSHOTS', True),
+                }
+            }
+        }
 
     def render_GET(self, request):
         """ handles get requests for metrics, health, and everything else """

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -195,6 +195,10 @@ class VmwareCollector():
 
         tasks = []
 
+        # Collect vm / snahpshot / vmguest metrics
+        if collect_only['vmguests'] is True or collect_only['vms'] is True or collect_only['snapshots'] is True:
+            tasks.append(self._vmware_get_vms(content, metrics, host_inventory))
+
         # Collect Datastore metrics
         if collect_only['datastores'] is True:
             tasks.append(threads.deferToThread(
@@ -212,10 +216,6 @@ class VmwareCollector():
                 metrics,
                 host_inventory,
             ))
-
-        # Collect vm / snahpshot / vmguest metrics
-        if collect_only['vmguests'] is True or collect_only['vms'] is True or collect_only['snapshots'] is True:
-           tasks.append(self._vmware_get_vms(content, metrics, host_inventory))
 
         # Waits for these to finish
         yield defer.DeferredList(tasks)


### PR DESCRIPTION
I had planned to do this work in the new year, but I paged in pyvmomi so much yesterday for #43 I figured i'd get it done early.

The current twisted web code doesn't actually support concurrent http requests. `generate_latest_metrics` is entirely blocking, so a 2nd scrape request will end up queueing. This could quite easily queue for long enough to hit the default prometheus timeouts.

This branch replaces `ThreadPoolExecutor` with the thread pool that is built into Twisted. This allows us to use deferreds (and in particular, `inlineCallbacks`) to do more fine grained thread interleaving. At the same time it allows us to run blocking API calls away from the event loop so twisted web can handle multiple connections - allowing multiple standalone ESXi or vCenters to be scraped in parallel with the same exporter. I think all blocking code now runs on the twisted thread pool, away from the event loop.

For a quick test i scraped 2 standalone ESXi boxes each with a couple hundred vms. It was able to scrape them in parallel. They started and finished at about the same time, taking about 6s total. 

This branch builds on #43 - once that is merged I will rebase on top. 

(Still fighting with precommit, but flake8 and dockerlint pass)