### PR TITLE
Add tests + CI (#47)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = vmware_exporter

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 source = vmware_exporter
+omit =
+    tests/*
+    setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,27 @@ language: python
 python:
   - "3.6"
 
-sudo: required
-
-services:
-  - docker
-
 cache: pip
 
-install:
-  - pip install -r requirements.txt -r requirements-tests.txt
-
 script:
-  - pytest --cov=. tests
+  - pip install -r requirements.txt -r requirements-tests.txt
   - flake8 vmware_exporter tests
+  - pytest --cov=. tests/unit
 
 after_success:
   - codecov
+
+jobs:
+  include:
+    - language: python
+      python: "3.6"
+      cache: pip
+
+      sudo: required
+      services:
+      - docker
+
+      script:
+      - pip install -r requirements.txt -r requirements-tests.txt
+      - pytest tests/integration
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - "3.6"
+
+sudo: required
+
+services:
+  - docker
+
+cache: pip
+
+install:
+  - pip install -r requirements.txt -r requirements-tests.txt
+
+script:
+  - pytest --cov=. tests
+  - flake8 vmware_exporter tests
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       cache: pip
 
       script:
-        - pip install -r requirements.txt -r requirements-tests.txt
+        - pip install -e . -r requirements.txt -r requirements-tests.txt
         - flake8 vmware_exporter tests
         - pytest --cov=. tests/unit
 
@@ -23,5 +23,5 @@ jobs:
       - docker
 
       script:
-      - pip install -r requirements.txt -r requirements-tests.txt
+      - pip install -e . -r requirements.txt -r requirements-tests.txt
       - pytest tests/integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
-language: python
-python:
-  - "3.6"
-
-cache: pip
-
-script:
-  - pip install -r requirements.txt -r requirements-tests.txt
-  - flake8 vmware_exporter tests
-  - pytest --cov=. tests/unit
-
-after_success:
-  - codecov
-
 jobs:
   include:
+    - language: python
+      python:
+        - "3.6"
+
+      cache: pip
+
+      script:
+        - pip install -r requirements.txt -r requirements-tests.txt
+        - flake8 vmware_exporter tests
+        - pytest --cov=. tests/unit
+
+      after_success:
+        - codecov
+
     - language: python
       python: "3.6"
       cache: pip
@@ -25,4 +25,3 @@ jobs:
       script:
       - pip install -r requirements.txt -r requirements-tests.txt
       - pytest tests/integration
-

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 pytest-docker-tools
 pytest
 pytest-cov
+pytest-twisted
 codecov
 flake8

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,5 @@
+pytest-docker-tools
+pytest
+pytest-cov
+codecov
+flake8

--- a/tests/integration/test_container_health.py
+++ b/tests/integration/test_container_health.py
@@ -1,0 +1,22 @@
+from pytest_docker_tools import container, build
+import requests
+
+
+vmware_exporter_image = build(path='.')
+
+vmware_exporter = container(
+    image='{vmware_exporter_image.id}',
+    ports={
+        '9272/tcp': None,
+    },
+)
+
+
+def test_container_starts(vmware_exporter):
+    container_addr = vmware_exporter.get_addr('9272/tcp')
+    assert requests.get('http://{}:{}/healthz'.format(*container_addr)).status_code == 200
+
+
+def test_container_404(vmware_exporter):
+    container_addr = vmware_exporter.get_addr('9272/tcp')
+    assert requests.get('http://{}:{}/meetrics'.format(*container_addr)).status_code == 404

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from pyVmomi import vim
+
+from vmware_exporter.helpers import batch_fetch_properties
+
+
+class FakeView(vim.ManagedObject):
+
+    def __init__(self):
+        super().__init__('dummy-moid')
+
+    def Destroy(self):
+        pass
+
+
+def test_batch_fetch_properties():
+    content = mock.Mock()
+
+    # There is strict parameter checking - this must be a ManagedObject, not a mock,
+    # but the real return value has methods with side effects. So we need to use a fake.
+    content.viewManager.CreateContainerView.return_value = FakeView()
+
+    prop1 = mock.Mock()
+    prop1.name = 'someprop'
+    prop1.val = 1
+
+    prop2 = mock.Mock()
+    prop2.name = 'someotherprop'
+    prop2.val = 2
+
+    mock_props = mock.Mock()
+    mock_props.obj._moId = 'vm:1'
+    mock_props.propSet = [prop1, prop2]
+
+    content.propertyCollector.RetrieveContents.return_value = [mock_props]
+
+    results = batch_fetch_properties(
+        content,
+        vim.Datastore,
+        ['someprop', 'someotherprop'],
+    )
+
+    assert results == {
+        'vm:1': {
+            'obj': mock_props.obj,
+            'id': 'vm:1',
+            'someprop': 1,
+            'someotherprop': 2,
+        }
+    }

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -2,13 +2,14 @@ import contextlib
 import datetime
 from unittest import mock
 
+import pytest
 import pytest_twisted
 import pytz
 from pyVmomi import vim
 from twisted.internet import defer
 from twisted.web.server import NOT_DONE_YET
 
-from vmware_exporter.vmware_exporter import HealthzResource, VmwareCollector, VMWareMetricsResource
+from vmware_exporter.vmware_exporter import main, HealthzResource, VmwareCollector, VMWareMetricsResource
 
 
 EPOCH = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
@@ -610,3 +611,8 @@ def test_vmware_resource_async_render_GET_errback():
     request.setResponseCode.assert_called_with(500)
     request.write.assert_called_with(b'# Collection failed')
     request.finish.assert_called_with()
+
+
+def test_main():
+    with pytest.raises(SystemExit):
+        main(['-h'])

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -624,12 +624,13 @@ def test_vmware_resource_async_render_GET_no_target():
 
     resource = VMWareMetricsResource(args)
 
-    with mock.patch('vmware_exporter.vmware_exporter.VmwareCollector') as Collector:
+    with mock.patch('vmware_exporter.vmware_exporter.VmwareCollector'):
         yield resource._async_render_GET(request)
 
     request.setResponseCode.assert_called_with(500)
     request.write.assert_called_with(b'No vsphere_host or target defined!\n')
     request.finish.assert_called_with()
+
 
 def test_main():
     with pytest.raises(SystemExit):

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -613,6 +613,24 @@ def test_vmware_resource_async_render_GET_errback():
     request.finish.assert_called_with()
 
 
+@pytest_twisted.inlineCallbacks
+def test_vmware_resource_async_render_GET_no_target():
+    request = mock.Mock()
+    request.args = {
+    }
+
+    args = mock.Mock()
+    args.config_file = None
+
+    resource = VMWareMetricsResource(args)
+
+    with mock.patch('vmware_exporter.vmware_exporter.VmwareCollector') as Collector:
+        yield resource._async_render_GET(request)
+
+    request.setResponseCode.assert_called_with(500)
+    request.write.assert_called_with(b'No vsphere_host or target defined!\n')
+    request.finish.assert_called_with()
+
 def test_main():
     with pytest.raises(SystemExit):
         main(['-h'])

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -136,11 +136,14 @@ def test_collect_vms(batch_fetch_properties):
 def test_collect_hosts(batch_fetch_properties):
     content = mock.Mock()
 
+    boot_time = EPOCH + datetime.timedelta(seconds=60)
+
     batch_fetch_properties.return_value = {
         'host-1': {
             'id': 'host:1',
             'name': 'host-1',
             'runtime.powerState': 'poweredOn',
+            'runtime.bootTime': boot_time,
             'runtime.connectionState': 'connected',
             'runtime.inMaintenanceMode': True,
             'summary.quickStats.overallCpuUsage': 100,

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+from vmware_exporter.vmware_exporter import VmwareCollector
+
+
+@mock.patch('vmware_exporter.vmware_exporter.batch_fetch_properties')
+def test_collect_datastore(batch_fetch_properties):
+    content = mock.Mock()
+
+    batch_fetch_properties.return_value = {
+        'datastore-1': {
+            'name': 'datastore-1',
+            'summary.capacity': 0,
+            'summary.freeSpace': 0,
+            'host': ['host-1'],
+            'vm': ['vm-1'],
+            'summary.accessible': True,
+            'summary.maintenanceMode': 'normal',
+        }
+    }
+
+    collect_only = {
+        'vms': True,
+        'vmguests': True,
+        'datastores': True,
+        'hosts': True,
+        'snapshots': True,
+    }
+    collector = VmwareCollector(
+        '127.0.0.1',
+        'root',
+        'password',
+        collect_only,
+    )
+
+    inventory = {
+        'datastore-1': {
+            'dc': 'dc',
+            'ds_cluster': 'ds_cluster',
+        }
+    }
+
+    metrics = collector._create_metric_containers()
+    collector._vmware_get_datastores(content, metrics, inventory)
+
+    assert metrics['vmware_datastore_capacity_size'].samples[0][1] == {
+        'ds_name': 'datastore-1',
+        'dc_name': 'dc',
+        'ds_cluster': 'ds_cluster'
+    }
+    assert metrics['vmware_datastore_capacity_size'].samples[0][2] == 0.0
+
+    assert metrics['vmware_datastore_maintenance_mode'].samples[0][1] == {
+        'ds_name': 'datastore-1',
+        'dc_name': 'dc',
+        'ds_cluster': 'ds_cluster',
+        'mode': 'normal'
+    }
+    assert metrics['vmware_datastore_maintenance_mode'].samples[0][2] == 1.0
+
+    assert metrics['vmware_datastore_accessible'].samples[0][1] == {
+        'ds_name': 'datastore-1',
+        'dc_name': 'dc',
+        'ds_cluster': 'ds_cluster'
+    }
+    assert metrics['vmware_datastore_accessible'].samples[0][2] == 1.0

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -5,7 +5,8 @@ import pytest_twisted
 import pytz
 from pyVmomi import vim
 
-from vmware_exporter.vmware_exporter import VmwareCollector
+from vmware_exporter.vmware_exporter import HealthzResource, VmwareCollector
+
 
 EPOCH = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
 
@@ -134,3 +135,14 @@ def test_collect_datastore(batch_fetch_properties):
         'ds_cluster': 'ds_cluster'
     }
     assert metrics['vmware_datastore_accessible'].samples[0][2] == 1.0
+
+
+def test_healthz():
+    request = mock.Mock()
+
+    resource = HealthzResource()
+    response = resource.render_GET(request)
+
+    request.setResponseCode.assert_called_with(200)
+
+    assert response == b'Server is UP'

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -1,6 +1,76 @@
+import datetime
 from unittest import mock
 
+import pytest_twisted
+import pytz
+from pyVmomi import vim
+
 from vmware_exporter.vmware_exporter import VmwareCollector
+
+EPOCH = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
+
+
+@mock.patch('vmware_exporter.vmware_exporter.batch_fetch_properties')
+@pytest_twisted.inlineCallbacks
+def test_collect_vms(batch_fetch_properties):
+    content = mock.Mock()
+
+    boot_time = EPOCH + datetime.timedelta(seconds=60)
+
+    batch_fetch_properties.return_value = {
+        'vm-1': {
+            'name': 'vm-1',
+            'runtime.host': vim.ManagedObject('host-1'),
+            'runtime.powerState': 'poweredOn',
+            'summary.config.numCpu': 1,
+            'runtime.bootTime': boot_time,
+        }
+    }
+
+    collect_only = {
+        'vms': True,
+        'vmguests': True,
+        'datastores': True,
+        'hosts': True,
+        'snapshots': True,
+    }
+    collector = VmwareCollector(
+        '127.0.0.1',
+        'root',
+        'password',
+        collect_only,
+    )
+
+    inventory = {
+        'host-1': {
+            'name': 'host-1',
+            'dc': 'dc',
+            'cluster': 'cluster-1',
+        }
+    }
+
+    metrics = collector._create_metric_containers()
+
+    collector._labels = {}
+
+    with mock.patch.object(collector, '_vmware_get_vm_perf_manager_metrics'):
+        yield collector._vmware_get_vms(content, metrics, inventory)
+
+    assert metrics['vmware_vm_power_state'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+    }
+    assert metrics['vmware_vm_power_state'].samples[0][2] == 1.0
+
+    assert metrics['vmware_vm_boot_timestamp_seconds'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+    }
+    assert metrics['vmware_vm_boot_timestamp_seconds'].samples[0][2] == 60
 
 
 @mock.patch('vmware_exporter.vmware_exporter.batch_fetch_properties')

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -376,6 +376,35 @@ def test_vmware_disconnect():
         connect.Disconnect.assert_called_with(connection)
 
 
+def test_vmware_perf_metrics():
+    counter = mock.Mock()
+    counter.groupInfo.key = 'a'
+    counter.nameInfo.key = 'b'
+    counter.rollupType = 'c'
+    counter.key = 1
+
+    content = mock.Mock()
+    content.perfManager.perfCounter = [counter]
+
+    collect_only = {
+        'vms': True,
+        'vmguests': True,
+        'datastores': True,
+        'hosts': True,
+        'snapshots': True,
+    }
+    collector = VmwareCollector(
+        '127.0.0.1',
+        'root',
+        'password',
+        collect_only,
+    )
+
+    result = collector._vmware_perf_metrics(content)
+
+    assert result == {'a.b.c': 1}
+
+
 def test_healthz():
     request = mock.Mock()
 

--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -162,7 +162,13 @@ def test_collect_vm_perf():
 
     collector._labels = {'vm:1': ['vm-1', 'host-1', 'dc', 'cluster-1']}
 
-    vms = {}
+    vms = {
+        'vm-1': {
+            'name': 'vm-1',
+            'obj': vim.ManagedObject('vm-1'),
+            'runtime.powerState': 'poweredOn',
+        }
+    }
 
     metric_1 = mock.Mock()
     metric_1.id.counterId = 9

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -42,12 +42,6 @@ class VmwareCollector():
         self.ignore_ssl = ignore_ssl
         self.collect_only = collect_only
 
-    def _future_done(self, future):
-        try:
-            future.result()
-        except Exception:
-            log(traceback.format_exc())
-
     def _create_metric_containers(self):
         metric_list = {}
         metric_list['vms'] = {

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import argparse
 import os
 import ssl
+import sys
 import traceback
 import pytz
 
@@ -716,7 +717,7 @@ def log(data):
     print("[{0}] {1}".format(datetime.utcnow().replace(tzinfo=pytz.utc), data))
 
 
-def main():
+def main(argv=None):
     """ start up twisted reactor """
     parser = argparse.ArgumentParser(description='VMWare metrics exporter for Prometheus')
     parser.add_argument('-c', '--config', dest='config_file',
@@ -724,7 +725,7 @@ def main():
     parser.add_argument('-p', '--port', dest='port', type=int,
                         default=9272, help="HTTP port to expose metrics")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv or sys.argv[1:])
 
     reactor.suggestThreadPoolSize(25)
 

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -48,13 +48,7 @@ class VmwareCollector():
         except Exception:
             log(traceback.format_exc())
 
-    @defer.inlineCallbacks
-    def collect(self):
-        """ collects metrics """
-        vsphere_host = self.host
-
-        host_inventory = {}
-        ds_inventory = {}
+    def _create_metric_containers(self):
         metric_list = {}
         metric_list['vms'] = {
             'vmware_vm_power_state': GaugeMetricFamily(
@@ -167,6 +161,18 @@ class VmwareCollector():
         for key, value in self.collect_only.items():
             if value is True:
                 metrics.update(metric_list[key])
+
+        return metrics
+
+    @defer.inlineCallbacks
+    def collect(self):
+        """ collects metrics """
+        vsphere_host = self.host
+
+        host_inventory = {}
+        ds_inventory = {}
+
+        metrics = self._create_metric_containers()
 
         log("Start collecting metrics from {0}".format(vsphere_host))
 


### PR DESCRIPTION
NOTE: This builds on top of #44, which must be merged first.

This uses `pytest` and `pytest-twisted` to do the main unit tests, and `pytest-docker-tools` to do integration testing of the Docker container itself.

It uses travis-ci.com for CI - you can see build output [here](https://travis-ci.com/Jc2k/vmware_exporter).

It uses codecov.io to see code coverage details. You can see example output [here](https://codecov.io/gh/Jc2k/vmware_exporter/branch/ci).

I'll try to get the coverage a little higher before removing the WIP tag.