### PR TITLE
feat(vmguests): adding vm tools related metrics (status, version, version status)

### DIFF
--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -84,6 +84,9 @@ def test_collect_vms():
                 'runtime.bootTime': boot_time,
                 'snapshot': snapshot,
                 'guest.disk': [disk],
+                'guest.toolsStatus': 'toolsOk',
+                'guest.toolsVersion': '10336',
+                'guest.toolsVersionStatus2': 'guestToolsUnmanaged',
             }
         })
         yield collector._vmware_get_vms(metrics)
@@ -115,6 +118,34 @@ def test_collect_vms():
         'partition': '/boot',
     }
     assert metrics['vmware_vm_guest_disk_capacity'].samples[0][2] == 100
+
+    # VM tools info (vmguest)
+    assert metrics['vmware_vm_guest_tools_running_status'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+        'tools_status': 'toolsOk',
+    }
+    assert metrics['vmware_vm_guest_tools_running_status'].samples[0][2] == 1.0
+
+    assert metrics['vmware_vm_guest_tools_version'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+        'tools_version': '10336',
+    }
+    assert metrics['vmware_vm_guest_tools_version'].samples[0][2] == 1.0
+
+    assert metrics['vmware_vm_guest_tools_version_status'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+        'tools_version_status': 'guestToolsUnmanaged',
+    }
+    assert metrics['vmware_vm_guest_tools_version_status'].samples[0][2] == 1.0
 
     # Snapshots
     assert metrics['vmware_vm_snapshots'].samples[0][1] == {

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -73,6 +73,18 @@ class VmwareCollector():
                 'vmware_vm_guest_disk_capacity',
                 'Disk capacity metric per partition',
                 labels=['vm_name', 'host_name', 'dc_name', 'cluster_name', 'partition', ]),
+            'vmware_vm_guest_tools_running_status': GaugeMetricFamily(
+                'vmware_vm_guest_tools_running_status',
+                'VM tools running status',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name', 'tools_status', ]),
+            'vmware_vm_guest_tools_version': GaugeMetricFamily(
+                'vmware_vm_guest_tools_version',
+                'VM tools version',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name', 'tools_version', ]),
+            'vmware_vm_guest_tools_version_status': GaugeMetricFamily(
+                'vmware_vm_guest_tools_version_status',
+                'VM tools version status',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name', 'tools_version_status', ]),
             }
         metric_list['snapshots'] = {
             'vmware_vm_snapshots': GaugeMetricFamily(
@@ -326,7 +338,12 @@ class VmwareCollector():
             ])
 
         if self.collect_only['vmguests'] is True:
-            properties.append('guest.disk')
+            properties.extend([
+                'guest.disk',
+                'guest.toolsStatus',
+                'guest.toolsVersion',
+                'guest.toolsVersionStatus2',
+            ])
 
         if self.collect_only['snapshots'] is True:
             properties.append('snapshot')
@@ -603,6 +620,21 @@ class VmwareCollector():
                     metrics['vmware_vm_guest_disk_capacity'].add_metric(
                         labels + [disk.diskPath], disk.capacity
                     )
+
+            if 'guest.toolsStatus' in row:
+                metrics['vmware_vm_guest_tools_running_status'].add_metric(
+                    labels + [row['guest.toolsStatus']], 1
+                )
+
+            if 'guest.toolsVersion' in row:
+                metrics['vmware_vm_guest_tools_version'].add_metric(
+                    labels + [row['guest.toolsVersion']], 1
+                )
+
+            if 'guest.toolsVersionStatus2' in row:
+                metrics['vmware_vm_guest_tools_version_status'].add_metric(
+                    labels + [row['guest.toolsVersionStatus2']], 1
+                )
 
             if 'snapshot' in row:
                 snapshots = self._vmware_full_snapshots_list(row['snapshot'].rootSnapshotList)


### PR DESCRIPTION
fixes #71 

let me know what you guys think, I've been testing this in my cluster and works quite well.

examples:
```
vmware_vm_guest_tools_running_status{cluster_name="***",dc_name="***",environment="***",host_name="***",instance="***",job="vmware-exporter",tools_status="toolsOk",vm_name="***"} | 1

vmware_vm_guest_tools_version{cluster_name="***",dc_name="***",environment="***",host_name="***",instance="***",job="vmware-exporter",tools_version="10304",vm_name="***"} | 1

vmware_vm_guest_tools_version_status{cluster_name="***",dc_name="***",environment="***",host_name="***",instance="***",job="vmware-exporter",tools_version_status="guestToolsUnmanaged",vm_name="***"} | 1
```

