### PR TITLE
Fixing case when the value of environment variables should be cast to boolean

### DIFF
--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -19,7 +19,8 @@ class FakeView(vim.ManagedObject):
 def test_get_bool_env_with_default_value():
     value = get_bool_env('INEXISTENT_ENV', True)
 
-    assert value == True
+    assert value
+
 
 def test_get_bool_env_with_a_valid_env():
     key = "TEST_BOOLEAN_VALUE"
@@ -28,7 +29,8 @@ def test_get_bool_env_with_a_valid_env():
 
     value = get_bool_env(key, False)
 
-    assert value == True
+    assert value
+
 
 def test_batch_fetch_properties():
     content = mock.Mock()

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,8 +1,10 @@
+import os
+
 from unittest import mock
 
 from pyVmomi import vim
 
-from vmware_exporter.helpers import batch_fetch_properties
+from vmware_exporter.helpers import batch_fetch_properties, get_bool_env
 
 
 class FakeView(vim.ManagedObject):
@@ -13,6 +15,20 @@ class FakeView(vim.ManagedObject):
     def Destroy(self):
         pass
 
+
+def test_get_bool_env_with_default_value():
+    value = get_bool_env('INEXISTENT_ENV', True)
+
+    assert value == True
+
+def test_get_bool_env_with_a_valid_env():
+    key = "TEST_BOOLEAN_VALUE"
+
+    os.environ[key] = "True"
+
+    value = get_bool_env(key, False)
+
+    assert value == True
 
 def test_batch_fetch_properties():
     content = mock.Mock()

--- a/vmware_exporter/helpers.py
+++ b/vmware_exporter/helpers.py
@@ -1,5 +1,10 @@
+import os
+
 from pyVmomi import vmodl
 
+
+def get_bool_env(key, default=None):
+    return bool(os.environ.get(key, default))
 
 def batch_fetch_properties(content, obj_type, properties):
     view_ref = content.viewManager.CreateContainerView(

--- a/vmware_exporter/helpers.py
+++ b/vmware_exporter/helpers.py
@@ -6,6 +6,7 @@ from pyVmomi import vmodl
 def get_bool_env(key, default=None):
     return bool(os.environ.get(key, default))
 
+
 def batch_fetch_properties(content, obj_type, properties):
     view_ref = content.viewManager.CreateContainerView(
         container=content.rootFolder,

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -31,7 +31,7 @@ from pyVim import connect
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client import CollectorRegistry, generate_latest
 
-from .helpers import batch_fetch_properties
+from .helpers import batch_fetch_properties, get_bool_env
 from .defer import parallelize, run_once_property
 
 
@@ -762,13 +762,13 @@ class VMWareMetricsResource(Resource):
                 'vsphere_host': os.environ.get('VSPHERE_HOST'),
                 'vsphere_user': os.environ.get('VSPHERE_USER'),
                 'vsphere_password': os.environ.get('VSPHERE_PASSWORD'),
-                'ignore_ssl': os.environ.get('VSPHERE_IGNORE_SSL', False),
+                'ignore_ssl': get_bool_env('VSPHERE_IGNORE_SSL', False),
                 'collect_only': {
-                    'vms': os.environ.get('VSPHERE_COLLECT_VMS', True),
-                    'vmguests': os.environ.get('VSPHERE_COLLECT_VMGUESTS', True),
-                    'datastores': os.environ.get('VSPHERE_COLLECT_DATASTORES', True),
-                    'hosts': os.environ.get('VSPHERE_COLLECT_HOSTS', True),
-                    'snapshots': os.environ.get('VSPHERE_COLLECT_SNAPSHOTS', True),
+                    'vms': get_bool_env('VSPHERE_COLLECT_VMS', True),
+                    'vmguests': get_bool_env('VSPHERE_COLLECT_VMGUESTS', True),
+                    'datastores': get_bool_env('VSPHERE_COLLECT_DATASTORES', True),
+                    'hosts': get_bool_env('VSPHERE_COLLECT_HOSTS', True),
+                    'snapshots': get_bool_env('VSPHERE_COLLECT_SNAPSHOTS', True),
                 }
             }
         }
@@ -785,13 +785,13 @@ class VMWareMetricsResource(Resource):
                 'vsphere_host': os.environ.get('VSPHERE_{}_HOST'.format(section)),
                 'vsphere_user': os.environ.get('VSPHERE_{}_USER'.format(section)),
                 'vsphere_password': os.environ.get('VSPHERE_{}_PASSWORD'.format(section)),
-                'ignore_ssl': os.environ.get('VSPHERE_{}_IGNORE_SSL'.format(section), False),
+                'ignore_ssl': get_bool_env('VSPHERE_{}_IGNORE_SSL'.format(section), False),
                 'collect_only': {
-                    'vms': os.environ.get('VSPHERE_{}_COLLECT_VMS'.format(section), True),
-                    'vmguests': os.environ.get('VSPHERE_{}_COLLECT_VMGUESTS'.format(section), True),
-                    'datastores': os.environ.get('VSPHERE_{}_COLLECT_DATASTORES'.format(section), True),
-                    'hosts': os.environ.get('VSPHERE_{}_COLLECT_HOSTS'.format(section), True),
-                    'snapshots': os.environ.get('VSPHERE_{}_COLLECT_SNAPSHOTS'.format(section), True),
+                    'vms': get_bool_env('VSPHERE_{}_COLLECT_VMS'.format(section), True),
+                    'vmguests': get_bool_env('VSPHERE_{}_COLLECT_VMGUESTS'.format(section), True),
+                    'datastores': get_bool_env('VSPHERE_{}_COLLECT_DATASTORES'.format(section), True),
+                    'hosts': get_bool_env('VSPHERE_{}_COLLECT_HOSTS'.format(section), True),
+                    'snapshots': get_bool_env('VSPHERE_{}_COLLECT_SNAPSHOTS'.format(section), True),
                 }
             }
 


### PR DESCRIPTION
**Issue**:

I'm trying to use this exporter inside a Kubernetes Pod based on the [example][k8s-settings] but the metrics were not exposed to Prometheus.

Investigating this, I've seen that the vmware_exporter doesn't cast the value from environment variables, that return string values, what causes the problem because they are used as boolean values (i.e [here][condition-example]).

**What this PR does**:

This PR cast the value from environment variables that should be boolean values.

**Approach**:

I've decided to create a function in `helpers` file because I believe that is the better place for it (if no, please comment).

**Notes**:

If someone has any concerns or suggestions about this, please comment.

**References**:

Environment variables that I've used locally to test:

```bash
export VSPHERE_USER='***'
export VSPHERE_PASSWORD='***'
export VSPHERE_HOST='***'
export VSPHERE_IGNORE_SSL=True

export VSPHERE_COLLECT_HOSTS=True
export VSPHERE_COLLECT_DATASTORES=True
export VSPHERE_COLLECT_VMS=True
export VSPHERE_COLLECT_VMGUESTS=True
export VSPHERE_COLLECT_SNAPSHOTS=True
```

Command used to run the container:

```bash
docker run -it --rm  \
  -p 9272:9272 \
  -e VSPHERE_USER \
  -e VSPHERE_PASSWORD \
  -e VSPHERE_HOST \
  -e VSPHERE_COLLECT_HOSTS \
  -e VSPHERE_COLLECT_DATASTORES \
  -e VSPHERE_COLLECT_VMS \
  -e VSPHERE_COLLECT_VMGUESTS \
  -e VSPHERE_COLLECT_SNAPSHOTS \
  --name 'vmware_exporter' \
  pryorda/vmware_exporter
```


[k8s-settings]: https://github.com/pryorda/vmware_exporter/tree/master/kubernetes
[condition-example]: https://github.com/pryorda/vmware_exporter/blob/master/vmware_exporter/vmware_exporter.py#L178