### PR TITLE
Refactoring of discovery for hosts and datastores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,56 @@
+---
+
 language: python
-python:
-- 3.6
-cache: pip
-jobs:
+dist: xenial  # required for Python >= 3.7
+sudo: required
+cache:
+  directories:
+    - "$HOME/.cache/pip"
+    - "$HOME/.pyenv"
+matrix:
   include:
-  - language: python
-    python:
-    - '3.6'
-    cache: pip
-    sudo: required
-    script:
-    - pip install -e . -r requirements.txt -r requirements-tests.txt
-    - grep -Rl packagecloud /etc/apt/ |sudo xargs rm -vf
-    - sudo apt-get update && sudo apt-get install -y nodejs npm && npm install -g dockerfilelint
-    - dockerfilelint ./Dockerfile
-    - flake8 vmware_exporter tests
-    - pytest --cov=. tests/unit
-    after_success:
-    - codecov
-  - language: python
-    python: '3.6'
-    cache: pip
-    sudo: required
-    services:
-    - docker
-    script:
-    - pip install -e . -r requirements.txt -r requirements-tests.txt
-    - pytest tests/integration
-    after_success:
-    - git config --global user.name "semantic-release (via TravisCI)"
-    - git config --global user.email "semantic-release@travis"
-    - pip install python-semantic-release
-    - semantic-release publish
-    - semantic-release changelog --post
+    - name: "Python 3.6 Unit-test"
+      python: 3.6
+    - name: "Python 3.7 Unit-test"
+      python: 3.7
+    - name: "Python 3.7 Docker Unit and Integration-test"
+      python: 3.7
+      services:
+        - docker
+      env:
+        - BUILD_SDIST=true
+        - INTEGRATION_TEST=true
+
+install:
+  - pip install -e . -r requirements.txt -r requirements-tests.txt
+  - grep -Rl packagecloud /etc/apt/ |sudo xargs rm -vf
+  - sudo apt-get update && sudo apt-get install -y nodejs npm
+  - npm install -g dockerfilelint
+  - if [ $INTEGRATION_TEST == "true" ]; then
+      pip install python-semantic-release;
+    fi
+
+script:
+  - dockerfilelint ./Dockerfile
+  - flake8 vmware_exporter tests
+  - pytest --cov=. -v tests/unit
+  - if [ $INTEGRATION_TEST == "true" ]; then
+      pytest tests/integration;
+    else
+      echo "Skipped Integration-Tests";
+    fi
+
+after_success:
+  - codecov
+  - if [ $INTEGRATION_TEST == "true" ]; then
+      git config --global user.name "semantic-release (via TravisCI)";
+      git config --global user.email "semantic-release@travis";
+      semantic-release publish;
+      semantic-release changelog --post;
+    fi
+
 env:
   global:
-  - secure: qC8DzqyxBiBBBUGLuNOO2O6XgmUaLhTi1ArfhYxVDjv5vTJvCNO1DpXfFqXJGR3wrRKe1DOddXildOEL7d7xX6Y3b+k3urnPfqnAM/Hvr0djqDWRPuZl89Fg1mrAvBV3LL/ZsrWKHDc3keD/vTcPAsrnJl3MdS5fMKBwEuDmhpnNdGk0Wty357WxWBaz1JYBoGaqbw0JWAAA5UdfyF3aOybRONXcVqnxqSeR43drBLSdAwBJVVhyv3IYX3HRMCP8vXz43LqWK16z8KVPyrwwzE2WXlq+2FypLtM4A/XOssx4M77MefIMC6ydAimLh33gYtaiuO7+fYipLlOlChNO/pxX43FM+7UuKWaL9MWaUvypmOGo+jp/y6PzbIDz/RH4T8mjaswIe22nyTR/Gbtph/58CISGGEtRNKXjE4/OD1gjodcNS2NkwNQimxjHv30rH4X4Z+JYU+I3iobpmWJ5WJsyMnS3jWkRluRgA+8djuRviK4sdIBwk2qC2AGuZ1c6EJbEN7f3sRIgtQMYd1JAiZVwYmRa08hpulvrZAzxqx/PfkaEOBFQrBwISkD2Oq3MGlDSV+sUe53TmRM1KO9y5fC8XnJHRJv5mw+iWaEIImP2muXufdm101oXNzHbs3hC2kYIFD+u1BoVDgWACUIkj2oRxMJ4p3ynlbccALUc8y0=
-  - secure: GWTsOe1CGvEi/n7k+c91UisQAf7UcofZKeO8EI6n0abRPQii0rfMIQ7fS2KFUyR7I/nk02YrZcd1etAGTVthc9K3YrUhM68eu+ztlUX6Sr5SM6PseYWkgf+G0I+IIoCpqSjwL/9J4jTP1hvNlP7nofUbo43OyEEX7ndNr1r8Ab0Zu48VYFj3sb3whMovakEVH5SIUe001Jix4wIZ9TYUNnSReNzMb8M+s/xK+RUnT3SYYutBbw0Dc+wTaaW/A5g1kSK35VZZ7OWN+l1Sc0xCa9tfJYKuxXFuyKmBRe3z1WUk+4yQxbGKQ0s47LpICo2qKm2iYoKVoWAGXBtWKCbLDoVy1tRTE3bcBMFbNsHXHT4+1F6djJjfr8ndFAoLpXyVBPsD3/ik8k7GzC7Gvam1fzCisjPDZFbdUpUCXU5HDrknB6yKNvekkltgkGajS0rzY6UPPiUdGccoXMngrS8FhD7zPxqfCtbK9WYBM5yXZ/kCgCqy0+dMu0+1iUR8h4hoQxonp2c7cAEnHMcd90o0IK8NEZMNpu5b/F+34/wj3cy+QYpE99pF5ztnPQfzUPZzR7rAl/TzesDLFVQceykYNczoD1YDMUFareV+nyzZp/W4gECaRkqgZxxfYcSUXQCaQfHWSvSdHHLaoIMzQi7lL1c6YxmWx8UireQEChbKfyw=
-  - secure: sbOF44qJH2JyblAVIgbVZ/xmIuF9+ypzmyB6EOvbMagAdcySxYEz7BIadIMtP8wWGM2TZQKFxUTJhJblSBbKAKdC/6o6RLUy/MxyCShJafr9NkBhhbLIzYdVGOC5TjswLBXtvNdTbyUgEu6NQnkBjVoBm8FXfhWxRWzJ7SJHSJYMOB8Fnr7gjxiMbenQUJYfRtVowmExrHq0WxyvNMxqKEW4qWFU3AwAZEc7M5hvf+Upju/rnHsBRZrm/RvfRdhQnAXPVaSJXMzy5Msa6KheqswczSSlLTgpUxCF412EXD2rZsjG3sRFMLnokVw983z2Kw4ov3Y7eYHBpmyz7wg9ICD4TdlbbAPJJIgY7lZzYYtt2sQ6DhLwsNZyCCXBGn6b8tmNiOXdRkZJU7aAW6yuXDSx6RZCRNfn4JFFt1o9yzEbea6oKfovB7cy/3d3ty4+3ud9ozXB9G/m7UzsjCvry7gIxEv2rVYtdNeOvslyftXXXzPl4IRJv99WcSmum0nuOpQrlvOzq+1yQNa3ImCRBkFmqUUa34FObzIaGegq4fD3kMKz9N+impQRvNI9WiDqtRvBJTCaP28ibUainxslW4Ep4rcmWo6synf2q6aWTrUPxXl0jvd6eIuCCvWPH7uLXZhL0dYm5ID/9BOCd3TZcvVjBKW0xWkFafNyt2USJto=
+    - secure: qC8DzqyxBiBBBUGLuNOO2O6XgmUaLhTi1ArfhYxVDjv5vTJvCNO1DpXfFqXJGR3wrRKe1DOddXildOEL7d7xX6Y3b+k3urnPfqnAM/Hvr0djqDWRPuZl89Fg1mrAvBV3LL/ZsrWKHDc3keD/vTcPAsrnJl3MdS5fMKBwEuDmhpnNdGk0Wty357WxWBaz1JYBoGaqbw0JWAAA5UdfyF3aOybRONXcVqnxqSeR43drBLSdAwBJVVhyv3IYX3HRMCP8vXz43LqWK16z8KVPyrwwzE2WXlq+2FypLtM4A/XOssx4M77MefIMC6ydAimLh33gYtaiuO7+fYipLlOlChNO/pxX43FM+7UuKWaL9MWaUvypmOGo+jp/y6PzbIDz/RH4T8mjaswIe22nyTR/Gbtph/58CISGGEtRNKXjE4/OD1gjodcNS2NkwNQimxjHv30rH4X4Z+JYU+I3iobpmWJ5WJsyMnS3jWkRluRgA+8djuRviK4sdIBwk2qC2AGuZ1c6EJbEN7f3sRIgtQMYd1JAiZVwYmRa08hpulvrZAzxqx/PfkaEOBFQrBwISkD2Oq3MGlDSV+sUe53TmRM1KO9y5fC8XnJHRJv5mw+iWaEIImP2muXufdm101oXNzHbs3hC2kYIFD+u1BoVDgWACUIkj2oRxMJ4p3ynlbccALUc8y0=
+    - secure: GWTsOe1CGvEi/n7k+c91UisQAf7UcofZKeO8EI6n0abRPQii0rfMIQ7fS2KFUyR7I/nk02YrZcd1etAGTVthc9K3YrUhM68eu+ztlUX6Sr5SM6PseYWkgf+G0I+IIoCpqSjwL/9J4jTP1hvNlP7nofUbo43OyEEX7ndNr1r8Ab0Zu48VYFj3sb3whMovakEVH5SIUe001Jix4wIZ9TYUNnSReNzMb8M+s/xK+RUnT3SYYutBbw0Dc+wTaaW/A5g1kSK35VZZ7OWN+l1Sc0xCa9tfJYKuxXFuyKmBRe3z1WUk+4yQxbGKQ0s47LpICo2qKm2iYoKVoWAGXBtWKCbLDoVy1tRTE3bcBMFbNsHXHT4+1F6djJjfr8ndFAoLpXyVBPsD3/ik8k7GzC7Gvam1fzCisjPDZFbdUpUCXU5HDrknB6yKNvekkltgkGajS0rzY6UPPiUdGccoXMngrS8FhD7zPxqfCtbK9WYBM5yXZ/kCgCqy0+dMu0+1iUR8h4hoQxonp2c7cAEnHMcd90o0IK8NEZMNpu5b/F+34/wj3cy+QYpE99pF5ztnPQfzUPZzR7rAl/TzesDLFVQceykYNczoD1YDMUFareV+nyzZp/W4gECaRkqgZxxfYcSUXQCaQfHWSvSdHHLaoIMzQi7lL1c6YxmWx8UireQEChbKfyw=
+    - secure: sbOF44qJH2JyblAVIgbVZ/xmIuF9+ypzmyB6EOvbMagAdcySxYEz7BIadIMtP8wWGM2TZQKFxUTJhJblSBbKAKdC/6o6RLUy/MxyCShJafr9NkBhhbLIzYdVGOC5TjswLBXtvNdTbyUgEu6NQnkBjVoBm8FXfhWxRWzJ7SJHSJYMOB8Fnr7gjxiMbenQUJYfRtVowmExrHq0WxyvNMxqKEW4qWFU3AwAZEc7M5hvf+Upju/rnHsBRZrm/RvfRdhQnAXPVaSJXMzy5Msa6KheqswczSSlLTgpUxCF412EXD2rZsjG3sRFMLnokVw983z2Kw4ov3Y7eYHBpmyz7wg9ICD4TdlbbAPJJIgY7lZzYYtt2sQ6DhLwsNZyCCXBGn6b8tmNiOXdRkZJU7aAW6yuXDSx6RZCRNfn4JFFt1o9yzEbea6oKfovB7cy/3d3ty4+3ud9ozXB9G/m7UzsjCvry7gIxEv2rVYtdNeOvslyftXXXzPl4IRJv99WcSmum0nuOpQrlvOzq+1yQNa3ImCRBkFmqUUa34FObzIaGegq4fD3kMKz9N+impQRvNI9WiDqtRvBJTCaP28ibUainxslW4Ep4rcmWo6synf2q6aWTrUPxXl0jvd6eIuCCvWPH7uLXZhL0dYm5ID/9BOCd3TZcvVjBKW0xWkFafNyt2USJto=

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Get VMware vCenter information:
 
 ## Usage
 
+*Requires Python >= 3.6*
+
 - Install with `$ python setup.py install` or via pip `$ pip install vmware_exporter`. The docker command below is preferred.
 - Create `config.yml` based on the configuration section. Some variables can be passed as environment variables
 - Run `$ vmware_exporter -c /path/to/your/config`

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -15,6 +15,7 @@ import ssl
 import sys
 import traceback
 import pytz
+import logging
 
 from yamlconfig import YamlConfig
 
@@ -187,7 +188,7 @@ class VmwareCollector():
 
         metrics = self._create_metric_containers()
 
-        log("Start collecting metrics from {0}".format(vsphere_host))
+        logging.info(f"Start collecting metrics from {vsphere_host}")
 
         self._labels = {}
 
@@ -213,7 +214,7 @@ class VmwareCollector():
 
         yield self._vmware_disconnect
 
-        log("Finished collecting metrics from {0}".format(vsphere_host))
+        logging.info(f"Finished collecting metrics from {vsphere_host}")
 
         return list(metrics.values())   # noqa: F705
 
@@ -242,19 +243,19 @@ class VmwareCollector():
             return vmware_connect
 
         except vmodl.MethodFault as error:
-            log("Caught vmodl fault: " + error.msg)
+            logging.error(f"Caught vmodl fault: {error.msg}")
             return None
 
     @run_once_property
     @defer.inlineCallbacks
     def content(self):
-        log("Retrieving service instance content")
+        logging.info("Retrieving service instance content")
         connection = yield self.connection
         content = yield threads.deferToThread(
             connection.RetrieveContent
         )
 
-        log("Retrieved service instance content")
+        logging.info("Retrieved service instance content")
         return content
 
     @defer.inlineCallbacks
@@ -271,7 +272,7 @@ class VmwareCollector():
     @run_once_property
     @defer.inlineCallbacks
     def datastore_inventory(self):
-        log("Fetching vim.Datastore inventory")
+        logging.info("Fetching vim.Datastore inventory")
         start = datetime.datetime.utcnow()
         properties = [
             'name',
@@ -289,13 +290,13 @@ class VmwareCollector():
             vim.Datastore,
             properties
         )
-        log("Fetched vim.Datastore inventory (%s)", datetime.datetime.utcnow() - start)
+        logging.info(f"Fetched vim.Datastore inventory ({datetime.datetime.utcnow() - start})")
         return datastores
 
     @run_once_property
     @defer.inlineCallbacks
     def host_system_inventory(self):
-        log("Fetching vim.HostSystem inventory")
+        logging.info("Fetching vim.HostSystem inventory")
         start = datetime.datetime.utcnow()
         properties = [
             'name',
@@ -315,13 +316,13 @@ class VmwareCollector():
             vim.HostSystem,
             properties,
         )
-        log("Fetched vim.HostSystem inventory (%s)", datetime.datetime.utcnow() - start)
+        logging.info(f"Fetched vim.HostSystem inventory ({datetime.datetime.utcnow() - start})")
         return host_systems
 
     @run_once_property
     @defer.inlineCallbacks
     def vm_inventory(self):
-        log("Fetching vim.VirtualMachine inventory")
+        logging.info("Fetching vim.VirtualMachine inventory")
         start = datetime.datetime.utcnow()
         properties = [
             'name',
@@ -352,7 +353,7 @@ class VmwareCollector():
             vim.VirtualMachine,
             properties,
         )
-        log("Fetched vim.VirtualMachine inventory (%s)", datetime.datetime.utcnow() - start)
+        logging.info(f"Fetched vim.VirtualMachine inventory ({datetime.datetime.utcnow() - start})")
         return virtual_machines
 
     @run_once_property
@@ -369,58 +370,66 @@ class VmwareCollector():
     @defer.inlineCallbacks
     def datastore_labels(self):
 
-        def _collect(dc, node):
+        def _collect(node, level=1, dc=None, storagePod=""):
             inventory = {}
-            for folder in node.childEntity:  # Iterate through datastore folders
-                if isinstance(folder, vim.Datastore):  # Unclustered datastore
-                    row = inventory[folder.name] = [
-                        folder.name,
-                        dc.name,
-                    ]
-                    if isinstance(node, vim.StoragePod):
-                        row.append(node.name)
-                    else:
-                        row.append('')
-
-                else:  # Folder is a Datastore Cluster
-                    inventory.update(_collect(dc, folder))
+            if isinstance(node, vim.Folder) and not isinstance(node, vim.StoragePod):
+                logging.debug(f"[Folder    ] {('-' * level).ljust(7)} {node.name}")
+                for child in node.childEntity:
+                    inventory.update(_collect(child, level+1, dc))
+            elif isinstance(node, vim.Datacenter):
+                logging.debug(f"[Datacenter] {('-' * level).ljust(7)} {node.name}")
+                inventory.update(_collect(node.datastoreFolder, level+1, node.name))
+            elif isinstance(node, vim.Folder) and isinstance(node, vim.StoragePod):
+                logging.debug(f"[StoragePod] {('-' * level).ljust(7)} {node.name}")
+                for child in node.childEntity:
+                    inventory.update(_collect(child, level+1, dc, node.name))
+            elif isinstance(node, vim.Datastore):
+                logging.debug(f"[Datastore ] {('-' * level).ljust(7)} {node.name}")
+                inventory[node.name] = [node.name, dc, storagePod]
+            else:
+                logging.debug(f"[?         ] {('-' * level).ljust(7)} {node}")
             return inventory
 
         labels = {}
         dcs = yield self.datacenter_inventory
         for dc in dcs:
-            result = yield threads.deferToThread(lambda: _collect(dc, dc.datastoreFolder))
+            result = yield threads.deferToThread(lambda: _collect(dc))
             labels.update(result)
-
         return labels
 
     @run_once_property
     @defer.inlineCallbacks
     def host_labels(self):
 
-        def _collect(dc, node):
-            host_inventory = {}
-            for folder in node.childEntity:
-                if hasattr(folder, 'host'):
-                    for host in folder.host:  # Iterate through Hosts in the Cluster
-                        host_name = host.summary.config.name.rstrip('.')
-                        host_inventory[host._moId] = [
-                            host_name,
-                            dc.name,
-                            folder.name if isinstance(folder, vim.ClusterComputeResource) else ''
-                        ]
-
-                if isinstance(folder, vim.Folder):
-                    host_inventory.update(_collect(dc, folder))
-
-            return host_inventory
+        def _collect(node, level=1, dc=None, folder=None):
+            inventory = {}
+            if isinstance(node, vim.Folder) and not isinstance(node, vim.StoragePod):
+                logging.debug(f"[Folder    ] {('-' * level).ljust(7)} {node.name}")
+                for child in node.childEntity:
+                    inventory.update(_collect(child, level+1, dc))
+            elif isinstance(node, vim.Datacenter):
+                logging.debug(f"[Datacenter] {('-' * level).ljust(7)} {node.name}")
+                inventory.update(_collect(node.hostFolder, level+1, node.name))
+            elif isinstance(node, vim.ComputeResource):
+                logging.debug(f"[ComputeRes] {('-' * level).ljust(7)} {node.name}")
+                for host in node.host:
+                    inventory.update(_collect(host, level+1, dc, node))
+            elif isinstance(node, vim.HostSystem):
+                logging.debug(f"[HostSystem] {('-' * level).ljust(7)} {node.name}")
+                inventory[node._moId] = [
+                    node.summary.config.name.rstrip('.'),
+                    dc,
+                    folder.name if isinstance(folder, vim.ClusterComputeResource) else ''
+                    ]
+            else:
+                logging.debug(f"[?         ] {('-' * level).ljust(7)} {node}")
+            return inventory
 
         labels = {}
         dcs = yield self.datacenter_inventory
         for dc in dcs:
-            result = yield threads.deferToThread(lambda: _collect(dc, dc.hostFolder))
+            result = yield threads.deferToThread(lambda: _collect(dc))
             labels.update(result)
-
         return labels
 
     @run_once_property
@@ -489,12 +498,15 @@ class VmwareCollector():
         Get Datastore information
         """
 
-        log("Starting datastore metrics collection")
         results, datastore_labels = yield parallelize(self.datastore_inventory, self.datastore_labels)
 
         for datastore_id, datastore in results.items():
-            name = datastore['name']
-            labels = datastore_labels[name]
+            try:
+                name = datastore['name']
+                labels = datastore_labels[name]
+            except KeyError as e:
+                logging.info(f"Key error, unable to register datastore {e}, datastores are {datastore_labels}")
+                continue
 
             ds_capacity = float(datastore.get('summary.capacity', 0))
             ds_freespace = float(datastore.get('summary.freeSpace', 0))
@@ -510,8 +522,8 @@ class VmwareCollector():
             ds_metrics['vmware_datastore_vms'].add_metric(labels, len(datastore.get('vm', [])))
 
             ds_metrics['vmware_datastore_maintenance_mode'].add_metric(
-                labels + [datastore.get('summary.maintenanceMode', 'unknown')],
-                1
+               labels + [datastore.get('summary.maintenanceMode', 'unknown')],
+               1
             )
 
             ds_metrics['vmware_datastore_type'].add_metric(
@@ -525,11 +537,11 @@ class VmwareCollector():
                     datastore['summary.accessible'] * 1,
                 )
 
-        log("Finished datastore metrics collection")
+        return results
 
     @defer.inlineCallbacks
     def _vmware_get_vm_perf_manager_metrics(self, vm_metrics):
-        log('START: _vmware_get_vm_perf_manager_metrics')
+        logging.info('START: _vmware_get_vm_perf_manager_metrics')
 
         virtual_machines, counter_info = yield parallelize(self.vm_inventory, self.counter_ids)
 
@@ -589,14 +601,14 @@ class VmwareCollector():
                     labels[ent.entity._moId],
                     float(sum(metric.value)),
                 )
-        log('FIN: _vmware_get_vm_perf_manager_metrics')
+        logging.info('FIN: _vmware_get_vm_perf_manager_metrics')
 
     @defer.inlineCallbacks
     def _vmware_get_vms(self, metrics):
         """
         Get VM information
         """
-        log("Starting vm metrics collection")
+        logging.info("Starting vm metrics collection")
 
         virtual_machines, vm_labels = yield parallelize(self.vm_inventory, self.vm_labels)
 
@@ -662,19 +674,23 @@ class VmwareCollector():
                         snapshot['timestamp_seconds'],
                     )
 
-        log("Finished vm metrics collection")
+        logging.info("Finished vm metrics collection")
 
     @defer.inlineCallbacks
     def _vmware_get_hosts(self, host_metrics):
         """
         Get Host (ESXi) information
         """
-        log("Starting host metrics collection")
+        logging.info("Starting host metrics collection")
 
         results, host_labels = yield parallelize(self.host_system_inventory, self.host_labels)
 
         for host_id, host in results.items():
-            labels = host_labels[host_id]
+            try:
+                labels = host_labels[host_id]
+            except KeyError as e:
+                logging.info(f"Key error, unable to register host {e}, host labels are {host_labels}")
+                continue
 
             # Power state
             power_state = 1 if host['runtime.powerState'] == 'poweredOn' else 0
@@ -734,7 +750,7 @@ class VmwareCollector():
                     float(host['summary.hardware.memorySize']) / 1024 / 1024
                 )
 
-        log("Finished host metrics collection")
+        logging.info("Finished host metrics collection")
         return results
 
 
@@ -763,7 +779,7 @@ class VMWareMetricsResource(Resource):
             try:
                 self.config = YamlConfig(args.config_file)
                 if 'default' not in self.config.keys():
-                    log("Error, you must have a default section in config file (for now)")
+                    logging.error("Error, you must have a default section in config file (for now)")
                     exit(1)
                 return
             except Exception as exception:
@@ -817,7 +833,7 @@ class VMWareMetricsResource(Resource):
         try:
             yield self.generate_latest_metrics(request)
         except Exception:
-            log(traceback.format_exc())
+            logging.error(traceback.format_exc())
             request.setResponseCode(500)
             request.write(b'# Collection failed')
             request.finish()
@@ -831,7 +847,7 @@ class VMWareMetricsResource(Resource):
         """ gets the latest metrics """
         section = request.args.get(b'section', [b'default'])[0].decode('utf-8')
         if section not in self.config.keys():
-            log("{} is not a valid section, using default".format(section))
+            logging.info("{} is not a valid section, using default".format(section))
             section = 'default'
 
         if self.config[section].get('vsphere_host') and self.config[section].get('vsphere_host') != "None":
@@ -842,7 +858,7 @@ class VMWareMetricsResource(Resource):
             vsphere_host = request.args.get(b'vsphere_host')[0].decode('utf-8')
         else:
             request.setResponseCode(500)
-            log("No vsphere_host or target defined")
+            logging.info("No vsphere_host or target defined")
             request.write(b'No vsphere_host or target defined!\n')
             request.finish()
             return
@@ -873,15 +889,8 @@ class HealthzResource(Resource):
     def render_GET(self, request):
         request.setHeader("Content-Type", "text/plain; charset=UTF-8")
         request.setResponseCode(200)
-        log("Service is UP")
+        logging.info("Service is UP")
         return 'Server is UP'.encode()
-
-
-def log(data, *args):
-    """
-    Log any message in a uniform format
-    """
-    print("[{0}] {1}".format(datetime.datetime.utcnow().replace(tzinfo=pytz.utc), data % args))
 
 
 def main(argv=None):
@@ -891,8 +900,15 @@ def main(argv=None):
                         default=None, help="configuration file")
     parser.add_argument('-p', '--port', dest='port', type=int,
                         default=9272, help="HTTP port to expose metrics")
+    parser.add_argument('-l', '--loglevel', dest='loglevel',
+                        default="INFO", help="Set application loglevel INFO, DEBUG")
 
     args = parser.parse_args(argv or sys.argv[1:])
+
+    numeric_level = getattr(logging, args.loglevel.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Invalid log level: {args.loglevel}")
+    logging.basicConfig(level=numeric_level, format='%(asctime)s %(levelname)s:%(message)s')
 
     reactor.suggestThreadPoolSize(25)
 
@@ -902,7 +918,7 @@ def main(argv=None):
     root.putChild(b'healthz', HealthzResource())
 
     factory = Site(root)
-    log("Starting web server on port {}".format(args.port))
+    logging.info(f"Starting web server on port {args.port}")
     endpoint = endpoints.TCP4ServerEndpoint(reactor, args.port)
     endpoint.listen(factory)
     reactor.run()


### PR DESCRIPTION
- Fix errors with more complicated folder structure
- Refactor static logging to fine tunable logging

Folder structs like the following will work now:

Folder (Root)
- Folder (Company)
  - Folder (Country)
    - Datacenter Folder
      - Project Folder (Compute Ressource or CCR here)
        - Customer related Folder
          - Production/Dev Folder (Compute Ressource or CCR here)

Signed-off-by: Martin Kremers <info@martinkremers.de>