### PR TITLE
fix(added more memory metrics):

### DIFF
--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -568,6 +568,10 @@ class VmwareCollector():
             'disk.read.average',
             'disk.write.average',
             'mem.usage.average',
+            'mem.consumed.average',
+            'mem.active.average',
+            'mem.swapped.average',
+            'mem.vmmemctl.average',
             'net.received.average',
             'net.transmitted.average',
         ]


### PR DESCRIPTION
Add missing memory metrics (current metrics just provides the recently touched memory pages)

see: https://www.vmware.com/support/developer/converter-sdk/conv51_apireference/memory_counters.html