### PR TITLE
Add hardware info and new vms metrics

### DIFF
--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -350,8 +350,16 @@ def test_no_error_onempty_vms():
     metric_2.id.counterId = 1
     metric_2.value = [1]
 
+    metric_3 = mock.Mock()
+    metric_3.id.counterId = 13
+    metric_3.value = [618]
+
+    metric_4 = mock.Mock()
+    metric_4.id.counterId = 18
+    metric_4.value = [5]
+
     ent_1 = mock.Mock()
-    ent_1.value = [metric_1, metric_2]
+    ent_1.value = [metric_1, metric_2, metric_3, metric_4]
     ent_1.entity = vim.ManagedObject('vm:1')
 
     content = mock.Mock()
@@ -369,6 +377,20 @@ def test_no_error_onempty_vms():
         'mem.usage.average': 8,
         'net.received.average': 9,
         'net.transmitted.average': 10,
+        'cpu.costop.summation': 11,
+        'cpu.idle.summation': 12,
+        'cpu.demand.average': 13,
+        'mem.consumed.average': 14,
+        'mem.active.average': 15,
+        'mem.swapped.average': 16,
+        'mem.vmmemctl.average': 17,
+        'disk.maxTotalLatency.latest': 18,
+        'net.multicastRx.summation': 19,
+        'net.multicastTx.summation': 20,
+        'net.broadcastTx.summation': 21,
+        'net.broadcastRx.summation': 22,
+        'net.droppedRx.summation': 23,
+        'net.droppedTx.summation': 24,
     })
 
     collector.__dict__['vm_labels'] = _succeed({'': []})
@@ -408,8 +430,16 @@ def test_collect_vm_perf():
     metric_2.id.counterId = 1
     metric_2.value = [1]
 
+    metric_3 = mock.Mock()
+    metric_3.id.counterId = 13
+    metric_3.value = [618]
+
+    metric_4 = mock.Mock()
+    metric_4.id.counterId = 18
+    metric_4.value = [5]
+
     ent_1 = mock.Mock()
-    ent_1.value = [metric_1, metric_2]
+    ent_1.value = [metric_1, metric_2, metric_3, metric_4]
     ent_1.entity = vim.ManagedObject('vm:1')
 
     content = mock.Mock()
@@ -427,6 +457,20 @@ def test_collect_vm_perf():
         'mem.usage.average': 8,
         'net.received.average': 9,
         'net.transmitted.average': 10,
+        'cpu.costop.summation': 11,
+        'cpu.idle.summation': 12,
+        'cpu.demand.average': 13,
+        'mem.consumed.average': 14,
+        'mem.active.average': 15,
+        'mem.swapped.average': 16,
+        'mem.vmmemctl.average': 17,
+        'disk.maxTotalLatency.latest': 18,
+        'net.multicastRx.summation': 19,
+        'net.multicastTx.summation': 20,
+        'net.broadcastTx.summation': 21,
+        'net.broadcastRx.summation': 22,
+        'net.droppedRx.summation': 23,
+        'net.droppedTx.summation': 24,
     })
 
     collector.__dict__['vm_labels'] = _succeed({
@@ -456,6 +500,22 @@ def test_collect_vm_perf():
         'dc_name': 'dc',
     }
     assert metrics['vmware_vm_net_transmitted_average'].samples[0][2] == 9.0
+
+    assert metrics['vmware_vm_cpu_demand_average'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+    }
+    assert metrics['vmware_vm_cpu_demand_average'].samples[0][2] == 618.0
+
+    assert metrics['vmware_vm_disk_maxTotalLatency_latest'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+    }
+    assert metrics['vmware_vm_disk_maxTotalLatency_latest'].samples[0][2] == 5.0
 
 
 @pytest_twisted.inlineCallbacks
@@ -500,6 +560,8 @@ def test_collect_hosts():
                 'summary.hardware.memorySize': 2048 * 1024 * 1024,
                 'summary.config.product.version': '6.0.0',
                 'summary.config.product.build': '6765062',
+                'summary.hardware.cpuModel': 'cpu_model1',
+                'summary.hardware.model': 'model1',
             },
             'host:2': {
                 'id': 'host:2',
@@ -515,6 +577,16 @@ def test_collect_hosts():
         'dc_name': 'dc',
         'cluster_name': 'cluster'
     }
+
+    assert metrics['vmware_host_hardware_info'].samples[0][1] == {
+        'host_name': 'host-1',
+        'dc_name': 'dc',
+        'cluster_name': 'cluster',
+        'hardware_model': 'model1',
+        'hardware_cpu_model': 'cpu_model1',
+    }
+    assert metrics['vmware_host_hardware_info'].samples[0][2] == 1
+
     assert metrics['vmware_host_memory_max'].samples[0][2] == 2048
     assert metrics['vmware_host_num_cpu'].samples[0][2] == 12
 

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -180,7 +180,6 @@ class VmwareCollector():
                 'vmware_host_hardware_info',
                 'A metric with a constant "1" value labeled by model and cpu model from the host.',
                 labels=['host_name', 'dc_name', 'cluster_name', 'hardware_model', 'hardware_cpu_model']),
-
             'vmware_host_product_info': GaugeMetricFamily(
                 'vmware_host_product_info',
                 'A metric with a constant "1" value labeled by version and build from os the host.',
@@ -582,7 +581,6 @@ class VmwareCollector():
             'mem.usage.average',
             'net.received.average',
             'net.transmitted.average',
-            # To Add
             'cpu.costop.summation',
             'cpu.idle.summation',
             'cpu.demand.average',

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -64,6 +64,10 @@ class VmwareCollector():
                 'vmware_vm_memory_max',
                 'VMWare VM Memory Max availability in Mbytes',
                 labels=['vm_name', 'host_name', 'dc_name', 'cluster_name']),
+            'vmware_vm_template': GaugeMetricFamily(
+                'vmware_vm_template',
+                'VMWare VM Template (true / false)',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name']),
             }
         metric_list['vmguests'] = {
             'vmware_vm_guest_disk_free': GaugeMetricFamily(
@@ -344,6 +348,7 @@ class VmwareCollector():
                 'runtime.bootTime',
                 'summary.config.numCpu',
                 'summary.config.memorySizeMB',
+                'summary.config.template',
             ])
 
         if self.collect_only['vmguests'] is True:
@@ -658,6 +663,9 @@ class VmwareCollector():
 
             if 'summary.config.memorySizeMB' in row:
                 metrics['vmware_vm_memory_max'].add_metric(labels, row['summary.config.memorySizeMB'])
+
+            if 'summary.config.template' in row:
+                metrics['vmware_vm_template'].add_metric(labels, row['summary.config.template'])
 
             if 'guest.disk' in row and len(row['guest.disk']) > 0:
                 for disk in row['guest.disk']:


### PR DESCRIPTION
In order to have more details and more metrics in grafana dashboards, i added the following metrics.

Add host hardware info :
            'summary.hardware.cpuModel',
            'summary.hardware.model',

Add Vms metrics :
            'cpu.costop.summation',
            'cpu.idle.summation',
            'cpu.demand.average',
            'mem.consumed.average',
            'mem.active.average',
            'mem.swapped.average',
            'mem.vmmemctl.average',
            'disk.maxTotalLatency.latest',
            'net.multicastRx.summation',
            'net.multicastTx.summation',
            'net.broadcastTx.summation',
            'net.broadcastRx.summation',
            'net.droppedRx.summation',
            'net.droppedTx.summation',

Tests are done