### PR TITLE
add vm max cpu usage metric and test

### DIFF
--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -84,6 +84,7 @@ def test_collect_vms():
                 'runtime.powerState': 'poweredOn',
                 'summary.config.numCpu': 1,
                 'summary.config.memorySizeMB': 1024,
+                'runtime.maxCpuUsage': 2400,
                 'runtime.bootTime': boot_time,
                 'snapshot': snapshot,
                 'guest.disk': [disk],
@@ -118,6 +119,7 @@ def test_collect_vms():
                 'runtime.powerState': 'poweredOn',
                 'summary.config.numCpu': 1,
                 'summary.config.memorySizeMB': 1024,
+                'runtime.maxCpuUsage': 2400,
                 'runtime.bootTime': boot_time,
                 'snapshot': snapshot,
                 'guest.disk': [disk],
@@ -130,6 +132,7 @@ def test_collect_vms():
                 'runtime.powerState': 'poweredOff',
                 'summary.config.numCpu': 1,
                 'summary.config.memorySizeMB': 1024,
+                'runtime.maxCpuUsage': 2400,
                 'runtime.bootTime': boot_time,
                 'snapshot': snapshot,
                 'guest.disk': [disk],
@@ -143,6 +146,7 @@ def test_collect_vms():
                 'runtime.powerState': 'poweredOff',
                 'summary.config.numCpu': 1,
                 'summary.config.memorySizeMB': 1024,
+                'runtime.maxCpuUsage': 2400,
                 'runtime.bootTime': boot_time,
                 'snapshot': snapshot,
                 'guest.disk': [disk],
@@ -258,6 +262,15 @@ def test_collect_vms():
     }
     assert metrics['vmware_vm_memory_max'].samples[0][2] == 1024
 
+    # Max Cpu
+    assert metrics['vmware_vm_max_cpu_usage'].samples[0][1] == {
+        'vm_name': 'vm-1',
+        'host_name': 'host-1',
+        'cluster_name': 'cluster-1',
+        'dc_name': 'dc',
+    }
+    assert metrics['vmware_vm_max_cpu_usage'].samples[0][2] == 2400
+
 
 @pytest_twisted.inlineCallbacks
 # @pytest.mark.skip
@@ -294,6 +307,7 @@ def test_metrics_without_hostaccess():
                 'runtime.powerState': 'poweredOn',
                 'summary.config.numCpu': 1,
                 'summary.config.memorySizeMB': 1024,
+                'runtime.maxCpuUsage': 2400,
                 'runtime.bootTime': boot_time,
                 'guest.disk': [disk],
                 'guest.toolsStatus': 'toolsOk',

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -67,6 +67,7 @@ class VmwareCollector():
             'vmware_vm_max_cpu_usage': GaugeMetricFamily(
                 'vmware_vm_max_cpu_usage',
                 'VMWare VM Cpu Max availability in hz',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name']),
             'vmware_vm_template': GaugeMetricFamily(
                 'vmware_vm_template',
                 'VMWare VM Template (true / false)',

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -64,6 +64,10 @@ class VmwareCollector():
                 'vmware_vm_memory_max',
                 'VMWare VM Memory Max availability in Mbytes',
                 labels=['vm_name', 'host_name', 'dc_name', 'cluster_name']),
+            'vmware_vm_max_cpu_usage': GaugeMetricFamily(
+                'vmware_vm_max_cpu_usage',
+                'VMWare VM Cpu Max availability in hz',
+                labels=['vm_name', 'host_name', 'dc_name', 'cluster_name']),
             }
         metric_list['vmguests'] = {
             'vmware_vm_guest_disk_free': GaugeMetricFamily(
@@ -344,6 +348,7 @@ class VmwareCollector():
                 'runtime.bootTime',
                 'summary.config.numCpu',
                 'summary.config.memorySizeMB',
+                'runtime.maxCpuUsage',
             ])
 
         if self.collect_only['vmguests'] is True:
@@ -658,6 +663,9 @@ class VmwareCollector():
 
             if 'summary.config.memorySizeMB' in row:
                 metrics['vmware_vm_memory_max'].add_metric(labels, row['summary.config.memorySizeMB'])
+
+            if 'runtime.maxCpuUsage' in row:
+                metrics['vmware_vm_max_cpu_usage'].add_metric(labels, row['runtime.maxCpuUsage'])
 
             if 'guest.disk' in row and len(row['guest.disk']) > 0:
                 for disk in row['guest.disk']:


### PR DESCRIPTION
add vm max cpu usage metric 'runtime.maxCpuUsage' to be able to calculate in grafana dashboard the cpu usage percentage per vm based on cpu.usagemhz.average counter