### PR TITLE
Ensure specs_size is an int

### DIFF
--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -1072,8 +1072,8 @@ def test_vmware_disconnect():
         '127.0.0.1',
         'root',
         'password',
-        5000,
         collect_only,
+        5000,
     )
 
     # Mock that we have a connection
@@ -1107,8 +1107,8 @@ def test_counter_ids():
         '127.0.0.1',
         'root',
         'password',
-        5000,
         collect_only,
+        5000,
     )
     collector.content = content
 

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -44,7 +44,7 @@ class VmwareCollector():
         self.password = password
         self.ignore_ssl = ignore_ssl
         self.collect_only = collect_only
-        self.specs_size = specs_size
+        self.specs_size = int(specs_size)
 
     def _create_metric_containers(self):
         metric_list = {}


### PR DESCRIPTION
Setting `VSPHERE_SPECS_SIZE` environment variable results in a `specs_size` that is actually a string.  This is the exception:

```
vmware_exporter    | 2020-01-14 20:07:00,759 INFO:Fetched vim.VirtualMachine inventory (0:00:00.472943)
vmware_exporter    | 2020-01-14 20:07:00,783 ERROR:Traceback (most recent call last):
vmware_exporter    |   File "/usr/local/lib/python3.6/site-packages/vmware_exporter/vmware_exporter.py", line 997, in _async_render_GET
vmware_exporter    |     yield self.generate_latest_metrics(request)
vmware_exporter    | twisted.internet.defer.FirstError: FirstError[#1, [Failure instance: Traceback: <class 'TypeError'>: 'str' object cannot be interpreted as an integer
vmware_exporter    | /usr/local/lib/python3.6/site-packages/twisted/internet/defer.py:460:callback
vmware_exporter    | /usr/local/lib/python3.6/site-packages/twisted/internet/defer.py:568:_startRunCallbacks
vmware_exporter    | /usr/local/lib/python3.6/site-packages/twisted/internet/defer.py:654:_runCallbacks
vmware_exporter    | /usr/local/lib/python3.6/site-packages/twisted/internet/defer.py:1475:gotResult
vmware_exporter    | --- <exception caught here> ---
vmware_exporter    | /usr/local/lib/python3.6/site-packages/twisted/internet/defer.py:1418:_inlineCallbacks
vmware_exporter    | /usr/local/lib/python3.6/site-packages/vmware_exporter/vmware_exporter.py:640:_vmware_get_vm_perf_manager_metrics
vmware_exporter    | ]]
vmware_exporter    | 
```

I built a docker image with this change and no longer get an exception.