### PR TITLE
Deprecate yamlconfig

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 pytest_docker_tools==0.2.0
-pytest==3.3
-pytest-cov==2.6.0
-pytest-twisted==1.8
-codecov==2.0.15
+pytest==5.4.1
+pytest-cov==2.8.1
+pytest-twisted==1.12
+codecov==2.0.17
 flake8==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ prometheus-client==0.0.19
 pytz
 pyvmomi>=6.5
 twisted>=14.0.2
-yamlconfig
+pyyaml
 service-identity

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -17,7 +17,7 @@ import traceback
 import pytz
 import logging
 
-from yamlconfig import YamlConfig
+import yaml
 
 # Twisted
 from twisted.web.server import Site, NOT_DONE_YET
@@ -938,7 +938,7 @@ class VMWareMetricsResource(Resource):
     def configure(self, args):
         if args.config_file:
             try:
-                self.config = YamlConfig(args.config_file)
+                with open(args.config_file) as cf: self.config = yaml.load(cf, Loader=yaml.FullLoader)
                 if 'default' not in self.config.keys():
                     logging.error("Error, you must have a default section in config file (for now)")
                     exit(1)

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -938,7 +938,9 @@ class VMWareMetricsResource(Resource):
     def configure(self, args):
         if args.config_file:
             try:
-                with open(args.config_file) as cf: self.config = yaml.load(cf, Loader=yaml.FullLoader)
+                with open(args.config_file) as cf:
+                    self.config = yaml.load(cf, Loader=yaml.FullLoader)
+
                 if 'default' not in self.config.keys():
                     logging.error("Error, you must have a default section in config file (for now)")
                     exit(1)


### PR DESCRIPTION
I replaced yamlconfig for PyYAML itself, using yaml.load to read the configuration yaml file.

