### PR TITLE
fix prometheus "no token" error

### DIFF
--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 # Generic imports
 import argparse
 import os
+import re
 import ssl
 import sys
 import traceback
@@ -1150,6 +1151,7 @@ class VmwareCollector():
                     metric._labelnames = labelnames[0:len(self._labelNames[metric_type])]
                     metric._labelnames += customAttributesLabelNames
                     metric._labelnames += labelnames[len(self._labelNames[metric_type]):]
+                    metric._labelnames = list(map(lambda x : re.sub('[^a-zA-Z0-9_]','_',x) , metric._labelnames))
 
     @defer.inlineCallbacks
     def _vmware_get_datastores(self, ds_metrics):

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -1151,7 +1151,7 @@ class VmwareCollector():
                     metric._labelnames = labelnames[0:len(self._labelNames[metric_type])]
                     metric._labelnames += customAttributesLabelNames
                     metric._labelnames += labelnames[len(self._labelNames[metric_type]):]
-                    metric._labelnames = list(map(lambda x : re.sub('[^a-zA-Z0-9_]','_',x) , metric._labelnames))
+                    metric._labelnames = list(map(lambda x: re.sub('[^a-zA-Z0-9_]', '_', x), metric._labelnames))
 
     @defer.inlineCallbacks
     def _vmware_get_datastores(self, ds_metrics):


### PR DESCRIPTION
prometheus won't scrape metrics with labels containing unexpected characters
got the regex from https://github.com/prometheus/client_python/blob/3627472bd3257c1763f69e55e21612a5c8d6f49a/prometheus_client/metrics_core.py#L10