### PR TITLE
fix prometheus "no token" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 
 LABEL MAINTAINER="Daniel Pryor <daniel@pryorda.net>"
 LABEL NAME=vmware_exporter
@@ -6,7 +6,7 @@ LABEL NAME=vmware_exporter
 WORKDIR /opt/vmware_exporter/
 COPY . /opt/vmware_exporter/
 
-RUN set -x; buildDeps="gcc python-dev musl-dev libffi-dev openssl openssl-dev" \
+RUN set -x; buildDeps="gcc python3-dev musl-dev libffi-dev openssl openssl-dev" \
  && apk add --no-cache --update $buildDeps \
  && pip install -r requirements.txt . \
  && apk del $buildDeps

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 # Generic imports
 import argparse
 import os
+import re
 import ssl
 import sys
 import traceback
@@ -1150,6 +1151,7 @@ class VmwareCollector():
                     metric._labelnames = labelnames[0:len(self._labelNames[metric_type])]
                     metric._labelnames += customAttributesLabelNames
                     metric._labelnames += labelnames[len(self._labelNames[metric_type]):]
+                    metric._labelnames = list(map(lambda x : re.sub('[^a-zA-Z0-9_]','_',x) , metric._labelnames))
 
     @defer.inlineCallbacks
     def _vmware_get_datastores(self, ds_metrics):

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -1151,7 +1151,7 @@ class VmwareCollector():
                     metric._labelnames = labelnames[0:len(self._labelNames[metric_type])]
                     metric._labelnames += customAttributesLabelNames
                     metric._labelnames += labelnames[len(self._labelNames[metric_type]):]
-                    metric._labelnames = list(map(lambda x : re.sub('[^a-zA-Z0-9_]','_',x) , metric._labelnames))
+                    metric._labelnames = list(map(lambda x: re.sub('[^a-zA-Z0-9_]', '_', x), metric._labelnames))
 
     @defer.inlineCallbacks
     def _vmware_get_datastores(self, ds_metrics):


### PR DESCRIPTION
prometheus won't scrape metrics with labels containing unexpected characters
got the regex from https://github.com/prometheus/client_python/blob/3627472bd3257c1763f69e55e21612a5c8d6f49a/prometheus_client/metrics_core.py#L10
