### PR TITLE
Update required PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ prometheus-client==0.0.19
 pytz
 pyvmomi>=6.5
 twisted>=14.0.2
-pyyaml
+pyyaml>=5.1
 service-identity


### PR DESCRIPTION
PyYAML version 5.1+ is required as earlier versions do not have FullLoader attribute.