### PR TITLE
Add manifests to support OpenShift

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,27 @@
+### Installing vmware_exporter in OpenShift
+
+Create the secret as described in the kubernetes documentation
+
+TODO: Use existing secret
+```
+read -s VSPHERE_PASSWORD
+oc create secret generic -n openshift-vsphere-infra vmware-exporter-password --from-literal=VSPHERE_PASSWORD=$VSPHERE_PASSWORD
+```
+
+Modify the `configmap.yaml` for your configuration and apply.
+
+```
+oc apply -f configmap.yaml
+```
+
+Apply the role, rolebinding, service, deployment and ServiceMonitor
+
+```
+oc apply -f rolebinding.yaml
+oc apply -f service.yaml
+oc apply -f deployment.yaml
+oc apply -f servicemonitor.yaml
+```
+
+
+

--- a/openshift/configmap.yaml
+++ b/openshift/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  VSPHERE_COLLECT_DATASTORES: "True"
+  VSPHERE_COLLECT_HOSTS: "True"
+  VSPHERE_COLLECT_SNAPSHOTS: "False"
+  VSPHERE_COLLECT_VMGUESTS: "True"
+  VSPHERE_COLLECT_VMS: "True"
+  VSPHERE_FETCH_ALARMS: "True"
+  VSPHERE_FETCH_CUSTOM_ATTRIBUTES: "True"
+  VSPHERE_FETCH_TAGS: "True"
+  VSPHERE_HOST: vcenter
+  VSPHERE_IGNORE_SSL: "True"
+  VSPHERE_USER: user
+kind: ConfigMap
+metadata:
+  labels:
+    app: vmware-exporter
+  name: vmware-exporter-config
+  namespace: openshift-vsphere-infra

--- a/openshift/deployment.yaml
+++ b/openshift/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmware-exporter
+  namespace: openshift-vsphere-infra
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: vmware-exporter
+      k8s-app: vmware-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vmware-exporter
+        k8s-app: vmware-exporter
+        release: vmware-exporter
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: vmware-exporter-config
+        - secretRef:
+            name: vmware-exporter-password
+        image: quay.io/jcallen/vmware_exporter:add_metrics
+        imagePullPolicy: Always
+        name: vmware-exporter
+        ports:
+        - containerPort: 9272
+          name: http
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/openshift/rolebinding.yaml
+++ b/openshift/rolebinding.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-vsphere-infra
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-vsphere-infra
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s

--- a/openshift/service.yaml
+++ b/openshift/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: vmware-exporter
+  name: metrics
+  namespace: openshift-vsphere-infra
+spec:
+  ports:
+  - name: metrics
+    port: 9272
+    protocol: TCP
+    targetPort: 9272
+  selector:
+    k8s-app: vmware-exporter
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/servicemonitor.yaml
+++ b/openshift/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: vmware-exporter
+  name: vmware
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - openshift-vsphere-infra
+  selector:
+    matchLabels:
+      k8s-app: vmware-exporter


### PR DESCRIPTION
This PR includes manifests to support installing vmware_exporter in
OpenShift and sending prometheus data directly to the existing instance.
