### PR TITLE
Fix crash when encountering unexpected sensor info

### DIFF
--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -1695,7 +1695,10 @@ class VmwareCollector():
             sensors = [s for s in sensors if ':' in s]
 
             for s in sensors:
-                sensor = dict(item.split("=") for item in s.split(":")[1:])
+                sensor = dict(item.split("=") for item in re.split(r':(?=\w+=)', s)[1:])
+
+                if not all(key in sensor for key in ['sensorStatus', 'name', 'type', 'unit', 'value']):
+                    continue
 
                 sensor_status = {
                     'red': 0,


### PR DESCRIPTION
This pull request fixes a crash when encountering unexpected sensor info by skipping such sensors.

```
numericSensorInfo:name=Super Micro Computer Inc. BMC Firmware (node 0) 46:10000 2.14:type=Software Components:sensorStatus=green:value=0:unitModifier=0:unit=

numericSensorInfo:name=VMware
```