### PR TITLE
Update vmware_exporter.py to add unit labels

### DIFF
--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -93,12 +93,12 @@ class VmwareCollector():
         # label names and ammount will be needed later to insert labels from custom attributes
         self._labelNames = {
             'vms': ['vm_name', 'host_name', 'dc_name', 'cluster_name'],
-            'vm_perf': ['vm_name', 'host_name', 'dc_name', 'cluster_name'],
+            'vm_perf': ['vm_name', 'host_name', 'dc_name', 'cluster_name', 'unit'],
             'vmguests': ['vm_name', 'host_name', 'dc_name', 'cluster_name'],
             'snapshots': ['vm_name', 'host_name', 'dc_name', 'cluster_name'],
             'datastores': ['ds_name', 'dc_name', 'ds_cluster'],
             'hosts': ['host_name', 'dc_name', 'cluster_name'],
-            'host_perf': ['host_name', 'dc_name', 'cluster_name'],
+            'host_perf': ['host_name', 'dc_name', 'cluster_name', 'unit'],
         }
 
         # if tags are gonna be fetched 'tags' will be a label too
@@ -1387,7 +1387,7 @@ class VmwareCollector():
                 for ent in results:
                     for metric in ent.value:
                         vm_metrics[metric_names[metric.id.counterId]].add_metric(
-                            labels[ent.entity._moId],
+                            labels[ent.entity._moId] + [content.perfManager.QueryPerfCounter([metric.id.counterId])[0].unitInfo.label],
                             float(sum(metric.value)),
                         )
 
@@ -1472,7 +1472,7 @@ class VmwareCollector():
             for ent in results:
                 for metric in ent.value:
                     host_metrics[metric_names[metric.id.counterId]].add_metric(
-                        labels[ent.entity._moId],
+                        labels[ent.entity._moId] + [content.perfManager.QueryPerfCounter([metric.id.counterId])[0].unitInfo.label],
                         float(sum(metric.value)),
                     )
 


### PR DESCRIPTION
Changed a few lines which will add a unit label for the vm_perf and host_perf. 

I noticed that a number of the metrics did not have units listed fot them and thus it was difficult to adequately use them. 