### PR TITLE
Add support for self-signed certificates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 config.yml
+certs/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.7-alpine
 LABEL MAINTAINER="Daniel Pryor <daniel@pryorda.net>"
 LABEL NAME=vmware_exporter
 
+# Install custom CA certificates, if any are given
+COPY certs/* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /opt/vmware_exporter/
 COPY . /opt/vmware_exporter/
 

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,46 @@
+# Custom CA certificates
+
+Add your existing CA certificates encoded as PEM-certificates into this directory. They will be added to the trusted root certificates of the alpine linux base system and respected by the underlying python library used to connect to your VirtualCenter server.
+
+## PEM encoded certificates
+A PEM-encoded certificate file starts with 
+
+`-----BEGIN CERTIFICATE-----`
+
+end ends with 
+
+`-----END CERTIFICATE-----`
+
+## Usage
+Store your custom root CA certificate into the `certs` folder. If you have a certificate chain, you will need to split the chain and store each certificate as a seperate file. 
+
+During `docker build` all files will be copied to `/usr/local/share/ca-certificates` and the command `update-ca-certificates` appends all certificates to the trusted root CA collection found at `/etc/ssl/certs/ca-certificates.crt`.
+
+`update-ca-certificates` will ignore files containing more than one certificate, which is the reason for splitting chains into individual files.
+
+## Certificate chain example
+**Note:** The certificates will be deployed using `update-ca-certicates`. During this step, the file extension `.pem` will be added to all files. To avoid a duplicate `.pem.pem` file extension, the exemplary filenames shown below have been stripped from a file extension altogether. You can name the files to your liking, of course.
+
+### root CA certificate
+**Filename:** `YOUR_ORG-root`[.pem]
+
+**Contents:**
+```
+-----BEGIN CERTIFICATE-----
+BQAwgYwxCzAJBgNVBAYTAkRFMRswGQYDVQQIExJCYWRlbi1XdWVydHRlbWJlcmcx
+...
+2uvOgYT/kkhCBM2fKS0domiDJE5iRrKzGOOQoh82Ya2P2epK6oHnaj6Zn+18o4k2
+-----END CERTIFICATE-----
+```
+
+### Intermediate CA certificate
+**Filename:** `YOUR_ORG-intermediate`[.pem]
+
+**Contents:**
+```
+-----BEGIN CERTIFICATE-----
+cnQxEjAQBgNVBAoTCXNod2lsbC5pbzEUMBIGA1UECxMLQ0EgU2VydmljZXMxIjAg
+...
++L9xUQZlXZeEyGmtwY5dyckDuRcUCYUZQAjR0MhSR4wZaCYyc+gnv6Mc6kJS6bCz
+-----END CERTIFICATE-----
+```


### PR DESCRIPTION
# Issue
If you are using self-signed certificates with a custom CA in your organisation, you need to supply the trusted root files to the trusted root CA store within alpine linux in order to make an SSL-encrypted connection. 

Disabling certificate verification with `VSPHERE_IGNORE_SSL=TRUE` is not viable in production environments.

# Solution
Add the trusted root certificates to the alpine linux trusted root store.

# Changes
- Added a `certs` directory, containing all required certificates of the chain split into individual files in PEM format
- Added documentation to `certs/README.md` to not push an empty directory. Added this readme to the `.dockerignore` file
- Updated `Dockerfile` to `COPY` all files within the `certs`-folder to `/usr/local/share/ca-certificates/`
- Updated `Dockerfile` to install the certificates by executing `update-ca-certificates`