### PR TITLE
Update dashboards

### DIFF
--- a/dashboards/cluster.json
+++ b/dashboards/cluster.json
@@ -31,7 +31,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "short",
       "gauge": {
         "maxValue": 100,
@@ -112,7 +112,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "hertz",
       "gauge": {
         "maxValue": 100,
@@ -193,7 +193,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "decmbytes",
       "gauge": {
         "maxValue": 100,
@@ -274,7 +274,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -355,7 +355,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -439,7 +439,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -504,7 +504,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -569,7 +569,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -638,7 +638,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -732,7 +732,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -807,7 +807,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -872,7 +872,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -941,7 +941,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1032,7 +1032,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1124,7 +1124,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1216,7 +1216,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1307,7 +1307,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1399,7 +1399,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1490,7 +1490,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1582,7 +1582,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1674,7 +1674,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1765,7 +1765,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1856,7 +1856,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1972,7 +1972,7 @@
             "cluster1"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "label_values(cluster_name)",
         "hide": 0,
         "includeAll": false,

--- a/dashboards/cluster.json
+++ b/dashboards/cluster.json
@@ -1944,7 +1944,9 @@
   ],
   "schemaVersion": 20,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "vmware"
+  ],
   "templating": {
     "list": [
       {

--- a/dashboards/esx.json
+++ b/dashboards/esx.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
+      "name": "datasource",
       "label": "prometheus",
       "description": "",
       "type": "datasource",
@@ -59,7 +59,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "decimals": 1,
           "description": "System uptime",
           "format": "s",
@@ -139,7 +139,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(245, 54, 54, 0.9)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "format": "percent",
           "gauge": {
             "maxValue": 100,
@@ -218,7 +218,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(245, 54, 54, 0.9)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "format": "percent",
           "gauge": {
             "maxValue": 100,
@@ -296,7 +296,7 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -385,7 +385,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "decimals": 1,
           "fill": 0,
           "id": 1,
@@ -468,7 +468,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "${datasource}",
           "decimals": 1,
           "fill": 1,
           "id": 2,
@@ -561,9 +561,26 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
         "label": "Host:",
@@ -612,6 +629,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "ESX Hosts Information",
+  "title": "VMware ESX Hosts Information",
+  "uid": "ed9d4bbf8801a8f79194b2ce6ead0ffcb8f9952a",
   "version": 17
 }

--- a/dashboards/esx.json
+++ b/dashboards/esx.json
@@ -557,7 +557,10 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "vmware",
+    "esx"
+  ],
   "templating": {
     "list": [
       {

--- a/dashboards/esxi.json
+++ b/dashboards/esxi.json
@@ -31,7 +31,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "short",
       "gauge": {
         "maxValue": 100,
@@ -114,7 +114,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -197,7 +197,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -280,7 +280,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -363,7 +363,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -446,7 +446,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "s",
       "gauge": {
         "maxValue": 100,
@@ -528,7 +528,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "short",
       "gauge": {
         "maxValue": 100,
@@ -610,7 +610,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "decmbytes",
       "gauge": {
         "maxValue": 100,
@@ -685,7 +685,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 4,
         "w": 4,
@@ -750,7 +750,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 4,
         "w": 4,
@@ -813,7 +813,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 4,
         "w": 4,
@@ -885,7 +885,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -964,7 +964,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1060,7 +1060,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1163,7 +1163,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1261,7 +1261,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1367,7 +1367,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1491,7 +1491,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1600,7 +1600,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1730,7 +1730,7 @@
           "text": "192.168.0.27",
           "value": "192.168.0.27"
         },
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "hide": 0,
         "includeAll": false,

--- a/dashboards/esxi.json
+++ b/dashboards/esxi.json
@@ -1701,7 +1701,6 @@
   "schemaVersion": 20,
   "style": "dark",
   "tags": [
-    "prometheus",
     "vmware",
     "esxi"
   ],

--- a/dashboards/virtualmachine.json
+++ b/dashboards/virtualmachine.json
@@ -1899,7 +1899,9 @@
   ],
   "schemaVersion": 20,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "vmware"
+  ],
   "templating": {
     "list": [
       {

--- a/dashboards/virtualmachine.json
+++ b/dashboards/virtualmachine.json
@@ -31,7 +31,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -114,7 +114,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -197,7 +197,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -284,7 +284,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -371,7 +371,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "short",
       "gauge": {
         "maxValue": 100,
@@ -459,7 +459,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -542,7 +542,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "short",
       "gauge": {
         "maxValue": 100,
@@ -617,7 +617,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 3,
@@ -682,7 +682,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 3,
@@ -747,7 +747,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 3,
@@ -819,7 +819,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "decmbytes",
       "gauge": {
         "maxValue": 100,
@@ -901,7 +901,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -976,7 +976,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 3,
@@ -1042,7 +1042,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "gridPos": {
         "h": 5,
         "w": 3,
@@ -1112,7 +1112,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1208,7 +1208,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1304,7 +1304,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1395,7 +1395,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1491,7 +1491,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1613,7 +1613,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
@@ -1710,7 +1710,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1811,7 +1811,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1925,7 +1925,7 @@
           "text": "centos-dhcp",
           "value": "centos-dhcp"
         },
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "label_values(vm_name)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
- This queries prometheus datasource name from first templated variable 'datasource' and use it in all panels. This ensures that dashboard would work in the grafana environment with any prometheus datasource name.

- Also prefixes esx.json dashboard with 'VMware' so dashboards are better sorted in grafana and easier to find.
- Adds common dashboard tags