### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyvmomi>=6.5
 twisted>=14.0.2
 pyyaml>=5.1
 service-identity
+requests


### PR DESCRIPTION
When i build the docker image from the dockerfile from pyorde/vmware_exporter, and use the image, the container crashes out with this error.

ModuleNotFoundError: No module named 'requests'
Traceback (most recent call last):
  File "/usr/local/bin/vmware_exporter", line 5, in <module>
    from vmware_exporter.vmware_exporter import main
  File "/usr/local/lib/python3.7/site-packages/vmware_exporter/vmware_exporter.py", line 21, in <module>
    import requests

i've forked the project, and added requests in requirements.txt
now when building the image from the fork, the problem is solved.