### PR TITLE
Update requirements.txt to include requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyvmomi>=6.5
 twisted>=14.0.2
 pyyaml>=5.1
 service-identity
+requests


### PR DESCRIPTION
Currently as it is, the Docker container built from the Dockerfile exits with the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/vmware_exporter", line 5, in <module>
    from vmware_exporter.vmware_exporter import main
  File "/usr/local/lib/python3.7/site-packages/vmware_exporter/vmware_exporter.py", line 21, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

This PR includes `requests` in the `requirements.txt` file.